### PR TITLE
Add alt_text to image files and nested attributes support

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -9,6 +9,9 @@ class ProjectsController < ApplicationController
   def create
     @project = Project.new(project_params)
     @project.depositor = current_user
+    if @project.image_file
+      @project.image_file.depositor_id = current_user.id
+    end
 
     if @project.save
       render json: @project, status: :created
@@ -18,7 +21,12 @@ class ProjectsController < ApplicationController
   end
 
   def update
-    if @project.update(project_params)
+    @project.assign_attributes(project_params)
+    if @project.image_file
+      @project.image_file.depositor_id = current_user.id
+    end
+
+    if @project.save
       render json: @project, status: :ok
     else
       render json: { errors: @project.errors.full_messages }, status: :unprocessable_entity
@@ -37,6 +45,7 @@ class ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:title, :description, :institution, :is_public)
+    params.require(:project).permit(:title, :description, :institution, :is_public,
+      image_file_attributes: [:id, :title, :alt_text, :file, :image_url, :_destroy])
   end
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -10,6 +10,7 @@ class Collection < ApplicationRecord
   belongs_to :depositor, class_name: "User"
   belongs_to :project
   has_one :image_file, as: :imageable
+  accepts_nested_attributes_for :image_file, allow_destroy: true
   has_many :collection_core_files, dependent: :destroy
   has_many :core_files, through: :collection_core_files
 

--- a/app/models/core_file.rb
+++ b/app/models/core_file.rb
@@ -15,6 +15,7 @@ class CoreFile < ApplicationRecord
   belongs_to :depositor, class_name: "User"
   has_one_attached :tei_file
   has_one :image_file, as: :imageable, dependent: :destroy
+  accepts_nested_attributes_for :image_file, allow_destroy: true
   has_many :collection_core_files, dependent: :destroy
   has_many :collections, through: :collection_core_files
 

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -7,6 +7,7 @@ class Project < ApplicationRecord
   # associations
   belongs_to :depositor, class_name: "User"
   has_one :image_file, as: :imageable, dependent: :destroy
+  accepts_nested_attributes_for :image_file, allow_destroy: true
   has_many :collections
   has_many :core_files, through: :collections
   has_many :project_members

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
          :trackable
 
   has_one :image_file, as: :imageable, dependent: :destroy
+  accepts_nested_attributes_for :image_file, allow_destroy: true
   has_many :project_members
   has_many :projects, through: :project_members
 

--- a/db/migrate/20260316000001_add_alt_text_to_image_files.rb
+++ b/db/migrate/20260316000001_add_alt_text_to_image_files.rb
@@ -1,0 +1,5 @@
+class AddAltTextToImageFiles < ActiveRecord::Migration[8.1]
+  def change
+    add_column :image_files, :alt_text, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_13_171831) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_16_000001) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -85,6 +85,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_13_171831) do
   end
 
   create_table "image_files", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.text "alt_text"
     t.datetime "created_at", null: false
     t.integer "depositor_id", null: false
     t.text "description"


### PR DESCRIPTION
## Summary

- Adds `alt_text` text column to `image_files` table via migration
- Adds `accepts_nested_attributes_for :image_file, allow_destroy: true` to `Project`, `Collection`, `CoreFile`, and `User` models, enabling image files to be created, updated, and destroyed through their parent record
- Updates `ProjectsController` to permit `image_file_attributes` in strong params (including `alt_text`) and to assign `depositor_id` on the image file during create and update

## Test plan

- [ ] Run existing model and request specs: `bundle exec rspec spec/models spec/requests`
- [ ] Verify migration applies cleanly: `rails db:migrate`
- [ ] Confirm `alt_text` is accepted when creating/updating an image file through a project
- [ ] Confirm `_destroy: true` removes an associated image file through a project

## Merge order

Merge this before `hotfix/core-file-model` — that branch's `core_file.rb` change is at a different line and will not conflict, but merging this first keeps history logical.