### PR TITLE
Fix double Solr indexing on CoreFile

### DIFF
--- a/app/models/core_file.rb
+++ b/app/models/core_file.rb
@@ -24,7 +24,7 @@ class CoreFile < ApplicationRecord
   scope :processing_completed, -> { where(processing_status: "completed") }
 
   # callbacks
-  after_save :index_core_file
+  after_create :index_core_file
   after_update :update_indexed_core_file
   after_create :enqueue_tapas_xq_processing
 


### PR DESCRIPTION
## Summary

- Changes `after_save :index_core_file` to `after_create :index_core_file` on `CoreFile`

`index_core_file` was firing on every save, causing duplicate Solr indexing on updates alongside the existing `after_update :update_indexed_core_file`. Scoping it to `after_create` means initial indexing happens once at creation; all subsequent updates are handled exclusively by `update_indexed_core_file`.

## Test plan

- [ ] `bundle exec rspec spec/models/core_file_spec.rb` — 47 examples, 0 failures (verified on branch)