### PR TITLE
Add CanCan authorization foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
 
     steps:
       - name: Install packages
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y default-libmysqlclient-dev
+        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y default-libmysqlclient-dev libmagickwand-dev
 
       - name: Checkout code
         uses: actions/checkout@v6

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,13 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  rescue_from CanCan::AccessDenied do |exception|
+    respond_to do |format|
+      format.json { render json: { error: exception.message }, status: :forbidden }
+      format.html { redirect_to root_path, alert: exception.message }
+    end
+  end
+
   helper Openseadragon::OpenseadragonHelper
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,12 +3,18 @@ class CollectionsController < ApplicationController
   before_action :set_collection, only: [ :update, :destroy ]
 
   def index
-    @collections = Collection.all
+    @collections = if current_user
+      member_project_ids = current_user.project_members.pluck(:project_id)
+      Collection.where(is_public: true).or(Collection.where(project_id: member_project_ids))
+    else
+      Collection.where(is_public: true)
+    end
   end
 
   def create
     @collection = Collection.new(collection_params)
     @collection.depositor = current_user
+    authorize! :create, @collection
 
     if @collection.save
       render json: @collection, status: :created
@@ -18,6 +24,7 @@ class CollectionsController < ApplicationController
   end
 
   def update
+    authorize! :update, @collection
     if @collection.update(collection_params)
       render json: @collection, status: :ok
     else
@@ -26,6 +33,7 @@ class CollectionsController < ApplicationController
   end
 
   def destroy
+    authorize! :destroy, @collection
     @collection.destroy
     head :no_content
   end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,13 +3,7 @@ class CollectionsController < ApplicationController
   before_action :set_collection, only: [ :update, :destroy ]
 
   def index
-    collections = if current_user
-      member_project_ids = current_user.project_members.pluck(:project_id)
-      Collection.where(is_public: true).or(Collection.where(project_id: member_project_ids))
-    else
-      Collection.where(is_public: true)
-    end
-    render json: collections
+    render json: Collection.accessible_by(current_ability)
   end
 
   def create

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -3,12 +3,13 @@ class CollectionsController < ApplicationController
   before_action :set_collection, only: [ :update, :destroy ]
 
   def index
-    @collections = if current_user
+    collections = if current_user
       member_project_ids = current_user.project_members.pluck(:project_id)
       Collection.where(is_public: true).or(Collection.where(project_id: member_project_ids))
     else
       Collection.where(is_public: true)
     end
+    render json: collections
   end
 
   def create

--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -3,10 +3,18 @@ class CoreFilesController < ApplicationController
   before_action :set_core_file, only: [ :update, :destroy ]
 
   def index
-    @core_files = CoreFile.all
+    @core_files = if current_user
+      member_project_ids = current_user.project_members.pluck(:project_id)
+      member_core_file_ids = CoreFile.joins(:collections)
+        .where(collections: { project_id: member_project_ids }).select(:id)
+      CoreFile.where(is_public: true).or(CoreFile.where(id: member_core_file_ids))
+    else
+      CoreFile.where(is_public: true)
+    end
   end
 
   def create
+    authorize! :create, CoreFile
     @core_file = CoreFile.new(core_file_params)
     @core_file.depositor = current_user
 
@@ -18,6 +26,7 @@ class CoreFilesController < ApplicationController
   end
 
   def update
+    authorize! :update, @core_file
     if @core_file.update(core_file_params)
       render json: @core_file, status: :ok
     else
@@ -26,6 +35,7 @@ class CoreFilesController < ApplicationController
   end
 
   def destroy
+    authorize! :destroy, @core_file
     @core_file.destroy
     head :no_content
   end

--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -3,7 +3,7 @@ class CoreFilesController < ApplicationController
   before_action :set_core_file, only: [ :update, :destroy ]
 
   def index
-    @core_files = if current_user
+    core_files = if current_user
       member_project_ids = current_user.project_members.pluck(:project_id)
       member_core_file_ids = CoreFile.joins(:collections)
         .where(collections: { project_id: member_project_ids }).select(:id)
@@ -11,6 +11,7 @@ class CoreFilesController < ApplicationController
     else
       CoreFile.where(is_public: true)
     end
+    render json: core_files
   end
 
   def create

--- a/app/controllers/core_files_controller.rb
+++ b/app/controllers/core_files_controller.rb
@@ -3,15 +3,7 @@ class CoreFilesController < ApplicationController
   before_action :set_core_file, only: [ :update, :destroy ]
 
   def index
-    core_files = if current_user
-      member_project_ids = current_user.project_members.pluck(:project_id)
-      member_core_file_ids = CoreFile.joins(:collections)
-        .where(collections: { project_id: member_project_ids }).select(:id)
-      CoreFile.where(is_public: true).or(CoreFile.where(id: member_core_file_ids))
-    else
-      CoreFile.where(is_public: true)
-    end
-    render json: core_files
+    render json: CoreFile.accessible_by(current_ability)
   end
 
   def create

--- a/app/controllers/project_members_controller.rb
+++ b/app/controllers/project_members_controller.rb
@@ -8,7 +8,9 @@ class ProjectMembersController < ApplicationController
   # POST /projects/:project_id/project_members
   def create
     authorize! :manage_members, @project
-    @member = @project.project_members.build(member_params)
+    @member = @project.project_members.build
+    @member.user = User.find(params.dig(:project_member, :user_id))
+    @member.role = params.dig(:project_member, :role)
 
     if @member.save
       render json: @member, status: :created
@@ -21,7 +23,9 @@ class ProjectMembersController < ApplicationController
   def update
     authorize! :manage_members, @project
 
-    if @member.update(member_params)
+    @member.role = params.dig(:project_member, :role) if params.dig(:project_member, :role).present?
+
+    if @member.save
       render json: @member, status: :ok
     else
       render json: { errors: @member.errors.full_messages }, status: :unprocessable_entity
@@ -49,10 +53,6 @@ class ProjectMembersController < ApplicationController
 
   def set_member
     @member = @project.project_members.find(params[:id])
-  end
-
-  def member_params
-    params.require(:project_member).permit(:user_id, :role)
   end
 
   def last_owner?

--- a/app/controllers/project_members_controller.rb
+++ b/app/controllers/project_members_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class ProjectMembersController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_project
+  before_action :set_member, only: [ :update, :destroy ]
+
+  # POST /projects/:project_id/project_members
+  def create
+    authorize! :manage_members, @project
+    @member = @project.project_members.build(member_params)
+
+    if @member.save
+      render json: @member, status: :created
+    else
+      render json: { errors: @member.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # PATCH /projects/:project_id/project_members/:id
+  def update
+    authorize! :manage_members, @project
+
+    if @member.update(member_params)
+      render json: @member, status: :ok
+    else
+      render json: { errors: @member.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /projects/:project_id/project_members/:id
+  def destroy
+    authorize! :manage_members, @project
+
+    if last_owner?
+      render json: { errors: [ "Cannot remove the last owner of a project" ] }, status: :unprocessable_entity
+      return
+    end
+
+    @member.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_project
+    @project = Project.find(params[:project_id])
+  end
+
+  def set_member
+    @member = @project.project_members.find(params[:id])
+  end
+
+  def member_params
+    params.require(:project_member).permit(:user_id, :role)
+  end
+
+  def last_owner?
+    @member.role == "owner" &&
+      @project.project_members.where(role: "owner").count == 1
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -57,6 +57,6 @@ class ProjectsController < ApplicationController
 
   def project_params
     params.require(:project).permit(:title, :description, :institution, :is_public,
-      image_file_attributes: [:id, :title, :alt_text, :file, :image_url, :_destroy])
+      image_file_attributes: [ :id, :title, :alt_text, :file, :image_url, :_destroy ])
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,13 +3,7 @@ class ProjectsController < ApplicationController
   before_action :set_project, only: [ :update, :destroy ]
 
   def index
-    @projects = if current_user
-      member_project_ids = current_user.project_members.pluck(:project_id)
-      Project.where(is_public: true).or(Project.where(id: member_project_ids))
-    else
-      Project.where(is_public: true)
-    end
-    render json: @projects
+    render json: Project.accessible_by(current_ability)
   end
 
   def create

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,10 +3,17 @@ class ProjectsController < ApplicationController
   before_action :set_project, only: [ :update, :destroy ]
 
   def index
-    @projects = Project.all
+    @projects = if current_user
+      member_project_ids = current_user.project_members.pluck(:project_id)
+      Project.where(is_public: true).or(Project.where(id: member_project_ids))
+    else
+      Project.where(is_public: true)
+    end
+    render json: @projects
   end
 
   def create
+    authorize! :create, Project
     @project = Project.new(project_params)
     @project.depositor = current_user
     if @project.image_file
@@ -21,6 +28,9 @@ class ProjectsController < ApplicationController
   end
 
   def update
+    authorize! :update, @project
+
+
     @project.assign_attributes(project_params)
     if @project.image_file
       @project.image_file.depositor_id = current_user.id
@@ -34,6 +44,7 @@ class ProjectsController < ApplicationController
   end
 
   def destroy
+    authorize! :destroy, @project
     @project.destroy
     head :no_content
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class UsersController < ApplicationController
+  before_action :authenticate_user!, only: [ :edit, :update ]
+  before_action :set_user
+
+  # GET /users/:id
+  def show
+    render json: @user
+  end
+
+  # GET /users/:id/edit
+  def edit
+    authorize! :edit, @user
+    render json: @user
+  end
+
+  # PATCH /users/:id
+  def update
+    authorize! :update, @user
+
+    if @user.update(user_params)
+      render json: @user, status: :ok
+    else
+      render json: { errors: @user.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :bio, :institution,
+      image_file_attributes: [ :id, :title, :alt_text, :file, :image_url, :_destroy ])
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+class Ability
+  include CanCan::Ability
+
+  def initialize(user)
+    user ||= User.new # guest user (not logged in)
+
+    if user.admin?
+      can :manage, :all
+      return
+    end
+
+    # --- Projects ---
+    # Anyone can read public projects
+    can :read, Project, is_public: true
+
+    if user.persisted?
+      can :create, Project
+
+      # Members (any role) can read projects they belong to
+      can :read, Project do |project|
+        project.project_members.exists?(user: user)
+      end
+
+      # Owners can update, destroy, and manage members
+      can [:update, :destroy, :manage_members], Project do |project|
+        project.project_members.exists?(user: user, role: "owner")
+      end
+    end
+
+    # --- Collections ---
+    can :read, Collection, is_public: true
+
+    if user.persisted?
+      can :read, Collection do |collection|
+        collection.project.project_members.exists?(user: user)
+      end
+
+      can :create, Collection do |collection|
+        collection.project&.project_members&.exists?(user: user)
+      end
+
+      can [:update, :destroy], Collection do |collection|
+        collection.depositor == user ||
+          collection.project.project_members.exists?(user: user, role: "owner")
+      end
+    end
+
+    # --- CoreFiles ---
+    can :read, CoreFile, is_public: true
+
+    if user.persisted?
+      can :read, CoreFile do |core_file|
+        project = core_file.project
+        project&.project_members&.exists?(user: user)
+      end
+
+      # Fine-grained create authorization (depositor must be project member)
+      # is enforced by the model's depositor_is_project_member validation
+      can :create, CoreFile
+
+      can [:update, :destroy], CoreFile do |core_file|
+        project = core_file.project
+        core_file.depositor == user ||
+          project&.project_members&.exists?(user: user, role: "owner")
+      end
+    end
+
+    # --- Users ---
+    if user.persisted?
+      can [:edit, :update], User, id: user.id
+    end
+
+    # --- ProjectMembers ---
+    if user.persisted?
+      can [:create, :update, :destroy], ProjectMember do |member|
+        member.project.project_members.exists?(user: user, role: "owner")
+      end
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -38,12 +38,11 @@ class Ability
       end
 
       can :create, Collection do |collection|
-        collection.project&.project_members&.exists?(user: user)
+        collection.project&.project_members&.exists?(user: user, role: "owner")
       end
 
       can [ :update, :destroy ], Collection do |collection|
-        collection.depositor == user ||
-          collection.project.project_members.exists?(user: user, role: "owner")
+        collection.project.project_members.exists?(user: user, role: "owner")
       end
     end
 
@@ -60,10 +59,12 @@ class Ability
       # is enforced by the model's depositor_is_project_member validation
       can :create, CoreFile
 
-      can [ :update, :destroy ], CoreFile do |core_file|
-        project = core_file.project
-        core_file.depositor == user ||
-          project&.project_members&.exists?(user: user, role: "owner")
+      can :update, CoreFile do |core_file|
+        core_file.project&.project_members&.exists?(user: user)
+      end
+
+      can :destroy, CoreFile do |core_file|
+        core_file.project&.project_members&.exists?(user: user, role: "owner")
       end
     end
 

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,7 +4,8 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    user ||= User.new # guest user (not logged in)
+    # User.new is not persisted, so guest users fall through all persisted? guards below
+    user ||= User.new
 
     if user.admin?
       can :manage, :all
@@ -18,10 +19,9 @@ class Ability
     if user.persisted?
       can :create, Project
 
-      # Members (any role) can read projects they belong to
-      can :read, Project do |project|
-        project.project_members.exists?(user: user)
-      end
+      # Members (any role) can read projects they belong to.
+      # Hash condition (not a block) so accessible_by can translate it to SQL.
+      can :read, Project, project_members: { user_id: user.id }
 
       # Owners can update, destroy, and manage members
       can [ :update, :destroy, :manage_members ], Project do |project|
@@ -33,9 +33,7 @@ class Ability
     can :read, Collection, is_public: true
 
     if user.persisted?
-      can :read, Collection do |collection|
-        collection.project.project_members.exists?(user: user)
-      end
+      can :read, Collection, project: { project_members: { user_id: user.id } }
 
       can :create, Collection do |collection|
         collection.project&.project_members&.exists?(user: user, role: "owner")
@@ -50,19 +48,18 @@ class Ability
     can :read, CoreFile, is_public: true
 
     if user.persisted?
-      can :read, CoreFile do |core_file|
-        project = core_file.project
-        project&.project_members&.exists?(user: user)
-      end
+      can :read, CoreFile, collections: { project: { project_members: { user_id: user.id } } }
 
       # Fine-grained create authorization (depositor must be project member)
       # is enforced by the model's depositor_is_project_member validation
       can :create, CoreFile
 
-      can :update, CoreFile do |core_file|
-        core_file.project&.project_members&.exists?(user: user)
-      end
+      can :update, CoreFile, collections: { project: { project_members: { user_id: user.id } } }
 
+      # TODO: The spec notes contributors can set configurations for their own records
+      # (e.g. default view package), which implies the depositor may have field-level
+      # permissions beyond what other members have. Flagged for Strategy Group review
+      # before implementing per-field update scoping.
       can :destroy, CoreFile do |core_file|
         core_file.project&.project_members&.exists?(user: user, role: "owner")
       end
@@ -70,7 +67,7 @@ class Ability
 
     # --- Users ---
     if user.persisted?
-      can [ :edit, :update ], User, id: user.id
+      can :update, User, id: user.id
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -71,12 +71,5 @@ class Ability
     if user.persisted?
       can [:edit, :update], User, id: user.id
     end
-
-    # --- ProjectMembers ---
-    if user.persisted?
-      can [:create, :update, :destroy], ProjectMember do |member|
-        member.project.project_members.exists?(user: user, role: "owner")
-      end
-    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -24,7 +24,7 @@ class Ability
       end
 
       # Owners can update, destroy, and manage members
-      can [:update, :destroy, :manage_members], Project do |project|
+      can [ :update, :destroy, :manage_members ], Project do |project|
         project.project_members.exists?(user: user, role: "owner")
       end
     end
@@ -41,7 +41,7 @@ class Ability
         collection.project&.project_members&.exists?(user: user)
       end
 
-      can [:update, :destroy], Collection do |collection|
+      can [ :update, :destroy ], Collection do |collection|
         collection.depositor == user ||
           collection.project.project_members.exists?(user: user, role: "owner")
       end
@@ -60,7 +60,7 @@ class Ability
       # is enforced by the model's depositor_is_project_member validation
       can :create, CoreFile
 
-      can [:update, :destroy], CoreFile do |core_file|
+      can [ :update, :destroy ], CoreFile do |core_file|
         project = core_file.project
         core_file.depositor == user ||
           project&.project_members&.exists?(user: user, role: "owner")
@@ -69,7 +69,7 @@ class Ability
 
     # --- Users ---
     if user.persisted?
-      can [:edit, :update], User, id: user.id
+      can [ :edit, :update ], User, id: user.id
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,8 +13,8 @@ class User < ApplicationRecord
   has_many :project_members
   has_many :projects, through: :project_members
 
-  def role
-    ProjectMember.find_by_user_id(id).role ||= "reader"
+  def role_in(project)
+    project_members.find_by(project: project)&.role
   end
 
   # Check if user is an admin based on admin_at timestamp

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,10 @@ Rails.application.routes.draw do
     registrations: "users/registrations"
   }
 
-  resources :projects
+  resources :projects do
+    resources :project_members, only: [ :create, :update, :destroy ]
+  end
+  resources :users, only: [ :show, :edit, :update ]
   resources :collections
   resources :core_files
 

--- a/spec/dashboards/core_file_dashboard_spec.rb
+++ b/spec/dashboards/core_file_dashboard_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe CoreFileDashboard do
   describe "COLLECTION_FILTERS behavior" do
     let(:depositor) { create(:user) }
     let(:project) { create(:project, depositor: depositor) }
-    let(:collection) { create(:collection, project: project, depositor: depositor) }
+    let(:collection) { create(:collection, project: project, depositor: depositor, is_public: true) }
 
     let!(:public_file) do
       create(:core_file, depositor: depositor, is_public: true).tap do |cf|

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,8 +1,9 @@
 FactoryBot.define do
   factory :collection do
     sequence(:title) { |n| "Test Collection #{n}" }
-    association :depositor, factory: :user
-    association :project
+    description { "A test collection description" }
     is_public { true }
+    association :depositor, factory: :user
+    project { association(:project, depositor: depositor) }
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -98,12 +98,11 @@ RSpec.describe Ability, type: :model do
     # Collections — can read all collections in member project (public and private)
     it { is_expected.to be_able_to(:read, public_collection) }
     it { is_expected.to be_able_to(:read, private_collection) }
-    it { is_expected.to be_able_to(:create, Collection.new(project: public_project)) }
-    it { is_expected.not_to be_able_to(:create, Collection.new(project: other_project)) }
 
-    # Can update/destroy own deposited collections; not others'
-    it { is_expected.to be_able_to(:update, own_collection) }
-    it { is_expected.to be_able_to(:destroy, own_collection) }
+    # Contributors cannot create, update, or destroy collections — owners only
+    it { is_expected.not_to be_able_to(:create, Collection.new(project: public_project)) }
+    it { is_expected.not_to be_able_to(:update, own_collection) }
+    it { is_expected.not_to be_able_to(:destroy, own_collection) }
     it { is_expected.not_to be_able_to(:update, public_collection) }
     it { is_expected.not_to be_able_to(:destroy, public_collection) }
 
@@ -111,10 +110,10 @@ RSpec.describe Ability, type: :model do
     it { is_expected.to be_able_to(:read, public_core_file) }
     it { is_expected.to be_able_to(:read, private_core_file) }
 
-    # Can update/destroy own deposited core files; not others'
+    # Contributors can update any core file in their project; cannot destroy (owners only)
     it { is_expected.to be_able_to(:update, own_core_file) }
-    it { is_expected.to be_able_to(:destroy, own_core_file) }
-    it { is_expected.not_to be_able_to(:update, public_core_file) }
+    it { is_expected.to be_able_to(:update, public_core_file) }
+    it { is_expected.not_to be_able_to(:destroy, own_core_file) }
     it { is_expected.not_to be_able_to(:destroy, public_core_file) }
   end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1,0 +1,166 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "cancan/matchers"
+
+RSpec.describe Ability, type: :model do
+  subject(:ability) { Ability.new(user) }
+
+  # Primary project and its resources (all deposited by `owner`)
+  let(:owner) { create(:user) }
+  let(:public_project) { create(:project, depositor: owner, is_public: true) }
+  let(:private_project) { create(:project, depositor: owner, is_public: false) }
+  let(:public_collection) { create(:collection, project: public_project, depositor: owner, is_public: true) }
+  let(:private_collection) { create(:collection, project: public_project, depositor: owner, is_public: false) }
+  let(:public_core_file) { create(:core_file, depositor: owner, collections: [ public_collection ], is_public: true) }
+  let(:private_core_file) { create(:core_file, depositor: owner, collections: [ public_collection ], is_public: false) }
+
+  # A separate project owned by someone else
+  let(:other_owner) { create(:user) }
+  let(:other_project) { create(:project, depositor: other_owner, is_public: false) }
+
+  context "as a guest" do
+    let(:user) { nil }
+
+    # Projects
+    it { is_expected.to be_able_to(:read, public_project) }
+    it { is_expected.not_to be_able_to(:read, private_project) }
+    it { is_expected.not_to be_able_to(:create, Project.new) }
+    it { is_expected.not_to be_able_to(:update, public_project) }
+    it { is_expected.not_to be_able_to(:destroy, public_project) }
+    it { is_expected.not_to be_able_to(:manage_members, public_project) }
+
+    # Collections
+    it { is_expected.to be_able_to(:read, public_collection) }
+    it { is_expected.not_to be_able_to(:read, private_collection) }
+    it { is_expected.not_to be_able_to(:create, Collection.new(project: public_project)) }
+    it { is_expected.not_to be_able_to(:update, public_collection) }
+    it { is_expected.not_to be_able_to(:destroy, public_collection) }
+
+    # CoreFiles
+    it { is_expected.to be_able_to(:read, public_core_file) }
+    it { is_expected.not_to be_able_to(:read, private_core_file) }
+    it { is_expected.not_to be_able_to(:create, CoreFile.new) }
+    it { is_expected.not_to be_able_to(:update, public_core_file) }
+    it { is_expected.not_to be_able_to(:destroy, public_core_file) }
+
+    # Users
+    it { is_expected.not_to be_able_to(:edit, owner) }
+    it { is_expected.not_to be_able_to(:update, owner) }
+  end
+
+  context "as a logged-in non-member" do
+    let(:user) { create(:user) }
+
+    # Projects
+    it { is_expected.to be_able_to(:read, public_project) }
+    it { is_expected.not_to be_able_to(:read, private_project) }
+    it { is_expected.to be_able_to(:create, Project.new) }
+    it { is_expected.not_to be_able_to(:update, public_project) }
+    it { is_expected.not_to be_able_to(:destroy, public_project) }
+    it { is_expected.not_to be_able_to(:manage_members, public_project) }
+
+    # Collections
+    it { is_expected.to be_able_to(:read, public_collection) }
+    it { is_expected.not_to be_able_to(:read, private_collection) }
+    it { is_expected.not_to be_able_to(:create, Collection.new(project: public_project)) }
+    it { is_expected.not_to be_able_to(:update, public_collection) }
+    it { is_expected.not_to be_able_to(:destroy, public_collection) }
+
+    # CoreFiles — ability permits create; model's depositor_is_project_member validates membership
+    it { is_expected.to be_able_to(:read, public_core_file) }
+    it { is_expected.not_to be_able_to(:read, private_core_file) }
+    it { is_expected.to be_able_to(:create, CoreFile.new) }
+    it { is_expected.not_to be_able_to(:update, public_core_file) }
+    it { is_expected.not_to be_able_to(:destroy, public_core_file) }
+
+    # Users — can only edit own profile
+    it { is_expected.to be_able_to(:edit, user) }
+    it { is_expected.to be_able_to(:update, user) }
+    it { is_expected.not_to be_able_to(:edit, owner) }
+    it { is_expected.not_to be_able_to(:update, owner) }
+  end
+
+  context "as a project contributor" do
+    let(:user) { create(:user) }
+    let(:own_collection) { create(:collection, project: public_project, depositor: user, is_public: true) }
+    let(:own_core_file) { create(:core_file, depositor: user, collections: [ public_collection ]) }
+
+    before { create(:project_member, project: public_project, user: user, role: "contributor") }
+
+    # Projects — member project readable; cannot manage
+    it { is_expected.to be_able_to(:read, public_project) }
+    it { is_expected.not_to be_able_to(:read, other_project) }
+    it { is_expected.not_to be_able_to(:update, public_project) }
+    it { is_expected.not_to be_able_to(:destroy, public_project) }
+    it { is_expected.not_to be_able_to(:manage_members, public_project) }
+
+    # Collections — can read all collections in member project (public and private)
+    it { is_expected.to be_able_to(:read, public_collection) }
+    it { is_expected.to be_able_to(:read, private_collection) }
+    it { is_expected.to be_able_to(:create, Collection.new(project: public_project)) }
+    it { is_expected.not_to be_able_to(:create, Collection.new(project: other_project)) }
+
+    # Can update/destroy own deposited collections; not others'
+    it { is_expected.to be_able_to(:update, own_collection) }
+    it { is_expected.to be_able_to(:destroy, own_collection) }
+    it { is_expected.not_to be_able_to(:update, public_collection) }
+    it { is_expected.not_to be_able_to(:destroy, public_collection) }
+
+    # CoreFiles — can read all core files in member project (public and private)
+    it { is_expected.to be_able_to(:read, public_core_file) }
+    it { is_expected.to be_able_to(:read, private_core_file) }
+
+    # Can update/destroy own deposited core files; not others'
+    it { is_expected.to be_able_to(:update, own_core_file) }
+    it { is_expected.to be_able_to(:destroy, own_core_file) }
+    it { is_expected.not_to be_able_to(:update, public_core_file) }
+    it { is_expected.not_to be_able_to(:destroy, public_core_file) }
+  end
+
+  context "as a project owner" do
+    let(:user) { owner }
+
+    # Projects — own projects fully manageable
+    it { is_expected.to be_able_to(:read, public_project) }
+    it { is_expected.to be_able_to(:read, private_project) }
+    it { is_expected.to be_able_to(:update, public_project) }
+    it { is_expected.to be_able_to(:destroy, public_project) }
+    it { is_expected.to be_able_to(:manage_members, public_project) }
+
+    # Projects — other user's projects not manageable
+    it { is_expected.not_to be_able_to(:update, other_project) }
+    it { is_expected.not_to be_able_to(:destroy, other_project) }
+    it { is_expected.not_to be_able_to(:manage_members, other_project) }
+
+    # Collections — full access within own project
+    it { is_expected.to be_able_to(:read, public_collection) }
+    it { is_expected.to be_able_to(:read, private_collection) }
+    it { is_expected.to be_able_to(:create, Collection.new(project: public_project)) }
+    it { is_expected.to be_able_to(:update, public_collection) }
+    it { is_expected.to be_able_to(:destroy, public_collection) }
+    it { is_expected.to be_able_to(:update, private_collection) }
+
+    # CoreFiles — full access within own project
+    it { is_expected.to be_able_to(:read, public_core_file) }
+    it { is_expected.to be_able_to(:read, private_core_file) }
+    it { is_expected.to be_able_to(:update, public_core_file) }
+    it { is_expected.to be_able_to(:destroy, public_core_file) }
+
+    # Users — own profile only
+    it { is_expected.to be_able_to(:edit, owner) }
+    it { is_expected.to be_able_to(:update, owner) }
+    it { is_expected.not_to be_able_to(:edit, other_owner) }
+    it { is_expected.not_to be_able_to(:update, other_owner) }
+  end
+
+  context "as an admin" do
+    let(:user) { create(:user, :admin) }
+
+    it { is_expected.to be_able_to(:manage, :all) }
+    it { is_expected.to be_able_to(:manage, public_project) }
+    it { is_expected.to be_able_to(:manage, public_collection) }
+    it { is_expected.to be_able_to(:manage, public_core_file) }
+    it { is_expected.to be_able_to(:manage, owner) }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -38,15 +38,15 @@ RSpec.describe User, type: :model do
     end
   end
 
-  describe '#role' do
+  describe '#role_in' do
     let(:depositor) { create(:user) }
     let(:project) { create(:project, depositor: depositor) }
 
     context 'when user is a project owner' do
       before { project } # trigger project creation so the depositor gets assigned as owner
 
-      it 'returns the role from project_members' do
-        expect(depositor.role).to eq('owner')
+      it 'returns "owner"' do
+        expect(depositor.role_in(project)).to eq('owner')
       end
     end
 
@@ -57,8 +57,18 @@ RSpec.describe User, type: :model do
         create(:project_member, :contributor, project: project, user: contributor)
       end
 
-      it 'returns contributor' do
-        expect(contributor.role).to eq('contributor')
+      it 'returns "contributor"' do
+        expect(contributor.role_in(project)).to eq('contributor')
+      end
+    end
+
+    context 'when user is not a member of the project' do
+      let(:non_member) { create(:user) }
+
+      before { project }
+
+      it 'returns nil' do
+        expect(non_member.role_in(project)).to be_nil
       end
     end
   end

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -4,12 +4,49 @@ require 'rails_helper'
 
 RSpec.describe "Collections", type: :request do
   let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
   let(:project) { create(:project, depositor: user) }
   let(:collection) { create(:collection, depositor: user, project: project) }
 
+  describe "GET /collections" do
+    let!(:public_collection) { create(:collection, depositor: user, project: project, is_public: true) }
+    let!(:private_collection) { create(:collection, depositor: user, project: project, is_public: false) }
+
+    context "as a guest" do
+      it "returns only public collections" do
+        get collections_path, as: :json
+        ids = JSON.parse(response.body).map { |c| c["id"] }
+        expect(ids).to include(public_collection.id)
+        expect(ids).not_to include(private_collection.id)
+      end
+    end
+
+    context "as the project owner" do
+      before { sign_in user }
+
+      it "returns public and own private collections" do
+        get collections_path, as: :json
+        ids = JSON.parse(response.body).map { |c| c["id"] }
+        expect(ids).to include(public_collection.id)
+        expect(ids).to include(private_collection.id)
+      end
+    end
+
+    context "as a non-member" do
+      before { sign_in other_user }
+
+      it "does not return private collections from other projects" do
+        get collections_path, as: :json
+        ids = JSON.parse(response.body).map { |c| c["id"] }
+        expect(ids).to include(public_collection.id)
+        expect(ids).not_to include(private_collection.id)
+      end
+    end
+  end
+
   describe "POST /collections" do
     let(:valid_params) { { collection: { title: "New Collection", description: "A description", project_id: project.id, is_public: true } } }
-    let(:invalid_params) { { collection: { title: "" } } }
+    let(:invalid_params) { { collection: { title: "", project_id: project.id } } }
 
     context "when not signed in" do
       it "redirects to sign in" do
@@ -20,6 +57,21 @@ RSpec.describe "Collections", type: :request do
       it "does not create a collection" do
         expect {
           post collections_path, params: valid_params
+        }.not_to change(Collection, :count)
+      end
+    end
+
+    context "when signed in as a non-member" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        post collections_path, params: valid_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not create a collection" do
+        expect {
+          post collections_path, params: valid_params, as: :json
         }.not_to change(Collection, :count)
       end
     end
@@ -78,6 +130,20 @@ RSpec.describe "Collections", type: :request do
   describe "PATCH /collections/:id" do
     let(:update_params) { { collection: { title: "Updated Title", description: "Updated description" } } }
 
+    context "when signed in as a non-owner non-depositor" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        patch collection_path(collection), params: update_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not update the collection" do
+        patch collection_path(collection), params: update_params, as: :json
+        expect(collection.reload.title).not_to eq("Updated Title")
+      end
+    end
+
     context "when not signed in" do
       it "redirects to sign in" do
         patch collection_path(collection), params: update_params
@@ -135,6 +201,22 @@ RSpec.describe "Collections", type: :request do
   end
 
   describe "DELETE /collections/:id" do
+    context "when signed in as a non-owner non-depositor" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        delete collection_path(collection), as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not delete the collection" do
+        collection # force creation
+        expect {
+          delete collection_path(collection), as: :json
+        }.not_to change(Collection, :count)
+      end
+    end
+
     context "when not signed in" do
       it "redirects to sign in" do
         delete collection_path(collection)

--- a/spec/requests/core_files_spec.rb
+++ b/spec/requests/core_files_spec.rb
@@ -4,9 +4,46 @@ require 'rails_helper'
 
 RSpec.describe "CoreFiles", type: :request do
   let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
   let(:project) { create(:project, depositor: user) }
   let(:collection) { create(:collection, project: project, depositor: user) }
   let(:core_file) { create(:core_file, depositor: user, collections: [ collection ]) }
+
+  describe "GET /core_files" do
+    let!(:public_core_file) { create(:core_file, depositor: user, collections: [ collection ], is_public: true) }
+    let!(:private_core_file) { create(:core_file, depositor: user, collections: [ collection ], is_public: false) }
+
+    context "as a guest" do
+      it "returns only public core files" do
+        get core_files_path, as: :json
+        ids = JSON.parse(response.body).map { |f| f["id"] }
+        expect(ids).to include(public_core_file.id)
+        expect(ids).not_to include(private_core_file.id)
+      end
+    end
+
+    context "as the project owner" do
+      before { sign_in user }
+
+      it "returns public and own private core files" do
+        get core_files_path, as: :json
+        ids = JSON.parse(response.body).map { |f| f["id"] }
+        expect(ids).to include(public_core_file.id)
+        expect(ids).to include(private_core_file.id)
+      end
+    end
+
+    context "as a non-member" do
+      before { sign_in other_user }
+
+      it "does not return private core files from other projects" do
+        get core_files_path, as: :json
+        ids = JSON.parse(response.body).map { |f| f["id"] }
+        expect(ids).to include(public_core_file.id)
+        expect(ids).not_to include(private_core_file.id)
+      end
+    end
+  end
 
   describe "POST /core_files" do
     let(:valid_params) { { core_file: { title: "New Core File", description: "A description", is_public: true, collection_ids: [ collection.id ] } } }
@@ -87,6 +124,23 @@ RSpec.describe "CoreFiles", type: :request do
         end
       end
 
+      context "as a non-member of the collection's project" do
+        before { sign_in other_user }
+
+        it "does not create the core file" do
+          expect {
+            post core_files_path, params: valid_params, as: :json
+          }.not_to change(CoreFile, :count)
+        end
+
+        it "returns unprocessable entity status" do
+          # CanCan permits any logged-in user to attempt create; the model's
+          # depositor_is_project_member validation rejects non-members with 422
+          post core_files_path, params: valid_params, as: :json
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+
       context "with collections from different projects" do
         let(:other_project) { create(:project, depositor: user) }
         let(:other_collection) { create(:collection, project: other_project, depositor: user) }
@@ -108,6 +162,20 @@ RSpec.describe "CoreFiles", type: :request do
 
   describe "PATCH /core_files/:id" do
     let(:update_params) { { core_file: { title: "Updated Title", description: "Updated description" } } }
+
+    context "when signed in as a non-owner non-depositor" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        patch core_file_path(core_file), params: update_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not update the core file" do
+        patch core_file_path(core_file), params: update_params, as: :json
+        expect(core_file.reload.title).not_to eq("Updated Title")
+      end
+    end
 
     context "when not signed in" do
       it "redirects to sign in" do
@@ -175,6 +243,22 @@ RSpec.describe "CoreFiles", type: :request do
   end
 
   describe "DELETE /core_files/:id" do
+    context "when signed in as a non-owner non-depositor" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        delete core_file_path(core_file), as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not delete the core file" do
+        core_file # force creation
+        expect {
+          delete core_file_path(core_file), as: :json
+        }.not_to change(CoreFile, :count)
+      end
+    end
+
     context "when not signed in" do
       it "redirects to sign in" do
         delete core_file_path(core_file)

--- a/spec/requests/project_members_spec.rb
+++ b/spec/requests/project_members_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ProjectMembers", type: :request do
+  let(:owner) { create(:user) }
+  let(:project) { create(:project, depositor: owner) }
+  let(:other_user) { create(:user) }
+  let(:contributor) { create(:user) }
+  let!(:contributor_member) { create(:project_member, project: project, user: contributor, role: "contributor") }
+
+  describe "POST /projects/:project_id/project_members" do
+    let(:valid_params) { { project_member: { user_id: other_user.id, role: "contributor" } } }
+
+    context "when not signed in" do
+      it "redirects to sign in" do
+        post project_project_members_path(project), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as the project owner" do
+      before { sign_in owner }
+
+      it "adds the user to the project" do
+        expect {
+          post project_project_members_path(project), params: valid_params
+        }.to change(ProjectMember, :count).by(1)
+      end
+
+      it "returns created status" do
+        post project_project_members_path(project), params: valid_params
+        expect(response).to have_http_status(:created)
+      end
+
+      it "assigns the specified role" do
+        post project_project_members_path(project), params: valid_params
+        expect(ProjectMember.last.role).to eq("contributor")
+      end
+
+      context "with an invalid role" do
+        it "returns unprocessable entity" do
+          post project_project_members_path(project),
+            params: { project_member: { user_id: other_user.id, role: "admin" } }
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+    end
+
+    context "when signed in as a non-owner" do
+      before { sign_in contributor }
+
+      it "returns forbidden" do
+        post project_project_members_path(project), params: valid_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not add a member" do
+        expect {
+          post project_project_members_path(project), params: valid_params, as: :json
+        }.not_to change(ProjectMember, :count)
+      end
+    end
+  end
+
+  describe "PATCH /projects/:project_id/project_members/:id" do
+    let(:update_params) { { project_member: { role: "owner" } } }
+
+    context "when not signed in" do
+      it "redirects to sign in" do
+        patch project_project_member_path(project, contributor_member), params: update_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as the project owner" do
+      before { sign_in owner }
+
+      it "updates the member's role" do
+        patch project_project_member_path(project, contributor_member), params: update_params
+        expect(contributor_member.reload.role).to eq("owner")
+      end
+
+      it "returns ok status" do
+        patch project_project_member_path(project, contributor_member), params: update_params
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when signed in as a non-owner" do
+      before { sign_in contributor }
+
+      it "returns forbidden" do
+        patch project_project_member_path(project, contributor_member), params: update_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "DELETE /projects/:project_id/project_members/:id" do
+    context "when not signed in" do
+      it "redirects to sign in" do
+        delete project_project_member_path(project, contributor_member)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as the project owner" do
+      before { sign_in owner }
+
+      it "removes the member" do
+        expect {
+          delete project_project_member_path(project, contributor_member)
+        }.to change(ProjectMember, :count).by(-1)
+      end
+
+      it "returns no content status" do
+        delete project_project_member_path(project, contributor_member)
+        expect(response).to have_http_status(:no_content)
+      end
+
+      context "when attempting to remove the last owner" do
+        let!(:owner_member) { project.project_members.find_by(user: owner, role: "owner") }
+
+        it "returns unprocessable entity" do
+          delete project_project_member_path(project, owner_member), as: :json
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+
+        it "does not remove the member" do
+          expect {
+            delete project_project_member_path(project, owner_member), as: :json
+          }.not_to change(ProjectMember, :count)
+        end
+      end
+    end
+
+    context "when signed in as a non-owner" do
+      before { sign_in contributor }
+
+      it "returns forbidden" do
+        delete project_project_member_path(project, contributor_member), as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -4,7 +4,49 @@ require 'rails_helper'
 
 RSpec.describe "Projects", type: :request do
   let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
   let(:project) { create(:project, depositor: user) }
+
+  describe "GET /projects" do
+    let!(:public_project) { create(:project, depositor: user, is_public: true) }
+    let!(:private_project) { create(:project, depositor: user, is_public: false) }
+    let!(:other_private_project) { create(:project, depositor: other_user, is_public: false) }
+
+    context "as a guest" do
+      it "returns only public projects" do
+        get projects_path
+        ids = JSON.parse(response.body).map { |p| p["id"] }
+        expect(ids).to include(public_project.id)
+        expect(ids).not_to include(private_project.id)
+        expect(ids).not_to include(other_private_project.id)
+      end
+    end
+
+    context "as the project owner" do
+      before { sign_in user }
+
+      it "returns public projects and own private projects" do
+        get projects_path
+        ids = JSON.parse(response.body).map { |p| p["id"] }
+        expect(ids).to include(public_project.id)
+        expect(ids).to include(private_project.id)
+        expect(ids).not_to include(other_private_project.id)
+      end
+    end
+
+    context "as a member of another user's private project" do
+      before do
+        create(:project_member, project: other_private_project, user: user)
+        sign_in user
+      end
+
+      it "returns the private project they are a member of" do
+        get projects_path
+        ids = JSON.parse(response.body).map { |p| p["id"] }
+        expect(ids).to include(other_private_project.id)
+      end
+    end
+  end
 
   describe "POST /projects" do
     let(:valid_params) { { project: { title: "New Project", description: "A description", institution: "NEU", is_public: true } } }
@@ -89,6 +131,20 @@ RSpec.describe "Projects", type: :request do
       end
     end
 
+    context "when signed in as a non-owner" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        patch project_path(project), params: update_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not update the project" do
+        patch project_path(project), params: update_params, as: :json
+        expect(project.reload.title).not_to eq("Updated Title")
+      end
+    end
+
     context "when signed in" do
       before { sign_in user }
 
@@ -144,6 +200,22 @@ RSpec.describe "Projects", type: :request do
         project # force creation
         expect {
           delete project_path(project)
+        }.not_to change(Project, :count)
+      end
+    end
+
+    context "when signed in as a non-owner" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        delete project_path(project), as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not delete the project" do
+        project # force creation
+        expect {
+          delete project_path(project), as: :json
         }.not_to change(Project, :count)
       end
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "Users", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  describe "GET /users/:id" do
+    it "is publicly accessible" do
+      get user_path(user)
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "does not require authentication" do
+      get user_path(user)
+      expect(response).not_to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "GET /users/:id/edit" do
+    context "when not signed in" do
+      it "redirects to sign in" do
+        get edit_user_path(user)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as the correct user" do
+      before { sign_in user }
+
+      it "returns ok" do
+        get edit_user_path(user)
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "when signed in as a different user" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        get edit_user_path(user), as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "PATCH /users/:id" do
+    let(:valid_params) { { user: { name: "Updated Name", bio: "A new bio", institution: "NEU" } } }
+
+    context "when not signed in" do
+      it "redirects to sign in" do
+        patch user_path(user), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when signed in as the correct user" do
+      before { sign_in user }
+
+      it "updates the user" do
+        patch user_path(user), params: valid_params
+        user.reload
+        expect(user.name).to eq("Updated Name")
+        expect(user.bio).to eq("A new bio")
+        expect(user.institution).to eq("NEU")
+      end
+
+      it "returns ok status" do
+        patch user_path(user), params: valid_params
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns the updated user as JSON" do
+        patch user_path(user), params: valid_params
+        json = JSON.parse(response.body)
+        expect(json["name"]).to eq("Updated Name")
+      end
+    end
+
+    context "when signed in as a different user" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        patch user_path(user), params: valid_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not update the user" do
+        patch user_path(user), params: valid_params, as: :json
+        expect(user.reload.name).not_to eq("Updated Name")
+      end
+    end
+  end
+end

--- a/spec/services/tapas_xq/storage_service_spec.rb
+++ b/spec/services/tapas_xq/storage_service_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe TapasXq::StorageService, type: :service do
   let(:depositor) { create(:user) }
   let(:project) { create(:project, depositor: depositor) }
-  let(:collection) { create(:collection, project: project, depositor: depositor) }
+  let(:collection) { create(:collection, project: project, depositor: depositor, is_public: true) }
   let(:core_file) do
     create(:core_file,
       depositor: depositor,


### PR DESCRIPTION
Main thing to look at: `app/models/ability.rb` — this is where all permission rules live. Would love a check on whether the rules for each resource (Projects, Collections, CoreFiles, Users) match expectations, and whether the approach for CoreFile create (flat `can :create` + model validation, rather than a block-based ability check) is acceptable.

Secondary: `app/controllers/project_members_controller.rb` for the ownership guard logic, and `spec/models/ability_spec.rb` to confirm the test coverage makes sense across the guest/contributor/owner/admin contexts.

Everything else (controller wiring, request specs) is pretty mechanical — happy to walk through any of it.