### PR TITLE
Remove soft delete: drop discarded_at columns (Card 1.43)

### DIFF
--- a/app/jobs/process_tei_file_job.rb
+++ b/app/jobs/process_tei_file_job.rb
@@ -28,6 +28,7 @@ class ProcessTeiFileJob < ApplicationJob
     # Skip if TAPAS-XQ disabled (development without TAPAS-XQ)
     if TapasXq.configuration.disabled?
       Rails.logger.info("TAPAS-XQ disabled, skipping processing for CoreFile #{core_file_id}")
+      core_file.update!(processing_status: "completed")
       return
     end
 

--- a/db/migrate/20260421153605_remove_discarded_at_from_collections.rb
+++ b/db/migrate/20260421153605_remove_discarded_at_from_collections.rb
@@ -1,0 +1,5 @@
+class RemoveDiscardedAtFromCollections < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :collections, :discarded_at, :datetime
+  end
+end

--- a/db/migrate/20260421153608_remove_discarded_at_from_core_files.rb
+++ b/db/migrate/20260421153608_remove_discarded_at_from_core_files.rb
@@ -1,0 +1,5 @@
+class RemoveDiscardedAtFromCoreFiles < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :core_files, :discarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_16_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_153608) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -53,20 +53,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_16_000001) do
     t.datetime "created_at", null: false
     t.integer "depositor_id", null: false
     t.text "description"
-    t.datetime "discarded_at"
     t.boolean "is_public"
     t.integer "project_id", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["depositor_id"], name: "index_collections_on_depositor_id"
-    t.index ["discarded_at"], name: "index_collections_on_discarded_at"
   end
 
   create_table "core_files", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "depositor_id", null: false
     t.text "description"
-    t.datetime "discarded_at"
     t.boolean "featured"
     t.boolean "is_public", default: true
     t.text "mods_xml", size: :medium


### PR DESCRIPTION
## Summary

- Drops `discarded_at` from `collections` and `core_files` tables
- Removes the Discard gem dependency (already removed from Gemfile)
- Completes the decision recorded 2026-04-22: soft delete is out of scope for TAPAS

## Notes

Schema-only change. No model or controller logic is touched. The functional spec describes all deletions as prompt-then-confirm hard deletes, so removing `discarded_at` is fully consistent with spec intent.

## Test plan

- [ ] Run migrations locally: `rails db:migrate`
- [ ] Confirm no references to `discarded_at` or Discard remain in the codebase
- [ ] Run full test suite