### PR TITLE
Remove soft delete: drop discarded_at columns and Discard gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,9 +37,6 @@ gem "mini_magick" # Image processing for ActiveStorage
 # URL & Routing
 gem "friendly_id", "~> 5.5" # URL slugs (updated from 5.2.4)
 
-# Soft Delete
-gem "discard", "~> 1.2"
-
 # Forms & Views
 gem "simple_form"
 gem "haml-rails", "~> 3.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,8 +161,6 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.6.2)
-    discard (1.4.0)
-      activerecord (>= 4.2, < 9.0)
     docile (1.4.1)
     domain_name (0.6.20240107)
     dotenv (3.2.0)
@@ -781,7 +779,6 @@ DEPENDENCIES
   dartsass-rails
   debug
   devise
-  discard (~> 1.2)
   dotenv-rails
   factory_bot_rails
   faker
@@ -876,7 +873,6 @@ CHECKSUMS
   descendants_tracker (0.0.4) sha256=e9c41dd4cfbb85829a9301ea7e7c48c2a03b26f09319db230e6479ccdc780897
   devise (5.0.2) sha256=254330c9290e612ad9681e8a18c96aa21fb95bc391af936b84480965444bb0b6
   diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
-  discard (1.4.0) sha256=6efcd2a53ddf96781f81b825d398f1c88ab88c0faa84e131bea6e16ef95d65d0
   docile (1.4.1) sha256=96159be799bfa73cdb721b840e9802126e4e03dfc26863db73647204c727f21e
   domain_name (0.6.20240107) sha256=5f693b2215708476517479bf2b3802e49068ad82167bcd2286f899536a17d933
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d

--- a/app/jobs/process_tei_file_job.rb
+++ b/app/jobs/process_tei_file_job.rb
@@ -28,6 +28,7 @@ class ProcessTeiFileJob < ApplicationJob
     # Skip if TAPAS-XQ disabled (development without TAPAS-XQ)
     if TapasXq.configuration.disabled?
       Rails.logger.info("TAPAS-XQ disabled, skipping processing for CoreFile #{core_file_id}")
+      core_file.update!(processing_status: "completed")
       return
     end
 

--- a/app/jobs/process_tei_file_job.rb
+++ b/app/jobs/process_tei_file_job.rb
@@ -28,7 +28,6 @@ class ProcessTeiFileJob < ApplicationJob
     # Skip if TAPAS-XQ disabled (development without TAPAS-XQ)
     if TapasXq.configuration.disabled?
       Rails.logger.info("TAPAS-XQ disabled, skipping processing for CoreFile #{core_file_id}")
-      core_file.update!(processing_status: "completed")
       return
     end
 

--- a/db/migrate/20260421153605_remove_discarded_at_from_collections.rb
+++ b/db/migrate/20260421153605_remove_discarded_at_from_collections.rb
@@ -1,0 +1,5 @@
+class RemoveDiscardedAtFromCollections < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :collections, :discarded_at, :datetime
+  end
+end

--- a/db/migrate/20260421153608_remove_discarded_at_from_core_files.rb
+++ b/db/migrate/20260421153608_remove_discarded_at_from_core_files.rb
@@ -1,0 +1,5 @@
+class RemoveDiscardedAtFromCoreFiles < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :core_files, :discarded_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_16_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_21_153608) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -53,20 +53,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_16_000001) do
     t.datetime "created_at", null: false
     t.integer "depositor_id", null: false
     t.text "description"
-    t.datetime "discarded_at"
     t.boolean "is_public"
     t.integer "project_id", null: false
     t.string "title", null: false
     t.datetime "updated_at", null: false
     t.index ["depositor_id"], name: "index_collections_on_depositor_id"
-    t.index ["discarded_at"], name: "index_collections_on_discarded_at"
   end
 
   create_table "core_files", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "depositor_id", null: false
     t.text "description"
-    t.datetime "discarded_at"
     t.boolean "featured"
     t.boolean "is_public", default: true
     t.text "mods_xml", size: :medium


### PR DESCRIPTION
## Summary

- Drops `discarded_at` from `collections` and `core_files` tables
- Removes the `discard` gem, which is now unused
- Completes the decision recorded 2026-04-22: soft delete is out of scope for TAPAS

## Test plan

- [ ] Run migrations: `rails db:migrate`
- [ ] Run full test suite