### PR TITLE
Add contact and website fields to Project (Card 1.48)

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -50,7 +50,7 @@ class ProjectsController < ApplicationController
   end
 
   def project_params
-    params.require(:project).permit(:title, :description, :institution, :is_public,
+    params.require(:project).permit(:title, :description, :institution, :is_public, :contact, :website,
       image_file_attributes: [ :id, :title, :alt_text, :file, :image_url, :_destroy ])
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,8 +1,11 @@
+require "uri"
+
 class Project < ApplicationRecord
   include SolrHelpers
 
   # validations
   validates_presence_of :depositor_id, :title
+  validates :website, format: { with: URI::DEFAULT_PARSER.make_regexp(%w[http https]), message: "must be a valid URL" }, allow_blank: true
 
   # associations
   belongs_to :depositor, class_name: "User"

--- a/db/migrate/20260422180203_add_contact_and_website_to_projects.rb
+++ b/db/migrate/20260422180203_add_contact_and_website_to_projects.rb
@@ -1,0 +1,6 @@
+class AddContactAndWebsiteToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :contact, :string
+    add_column :projects, :website, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_21_153608) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_22_180203) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -107,6 +107,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_153608) do
   end
 
   create_table "projects", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "contact"
     t.datetime "created_at", null: false
     t.integer "depositor_id", null: false
     t.text "description"
@@ -114,6 +115,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_21_153608) do
     t.boolean "is_public", default: true
     t.string "title", null: false
     t.datetime "updated_at", null: false
+    t.string "website"
     t.index ["depositor_id"], name: "index_projects_on_depositor_id"
   end
 


### PR DESCRIPTION
## Summary

- Adds `contact` and `website` string columns to the `projects` table
- `website` is validated as a valid http/https URL when present

## Test plan

- [ ] Run migrations: `rails db:migrate`
- [ ] Run full test suite