### PR TITLE
Add collection-scoped permissions for project members

### DIFF
--- a/app/controllers/project_members_controller.rb
+++ b/app/controllers/project_members_controller.rb
@@ -13,6 +13,7 @@ class ProjectMembersController < ApplicationController
     @member.role = params.dig(:project_member, :role)
 
     if @member.save
+      set_collection_scopes(@member, params[:collection_ids])
       render json: @member, status: :created
     else
       render json: { errors: @member.errors.full_messages }, status: :unprocessable_entity
@@ -26,6 +27,7 @@ class ProjectMembersController < ApplicationController
     @member.role = params.dig(:project_member, :role) if params.dig(:project_member, :role).present?
 
     if @member.save
+      replace_collection_scopes(@member, params[:collection_ids]) if params.key?(:collection_ids)
       render json: @member, status: :ok
     else
       render json: { errors: @member.errors.full_messages }, status: :unprocessable_entity
@@ -58,5 +60,17 @@ class ProjectMembersController < ApplicationController
   def last_owner?
     @member.role == "owner" &&
       @project.project_members.where(role: "owner").count == 1
+  end
+
+  def set_collection_scopes(member, collection_ids)
+    return if collection_ids.blank? || member.role == "owner"
+    Array(collection_ids).each do |collection_id|
+      member.collection_scopes.find_or_create_by!(collection_id: collection_id)
+    end
+  end
+
+  def replace_collection_scopes(member, collection_ids)
+    member.collection_scopes.destroy_all
+    set_collection_scopes(member, collection_ids)
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,7 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    user ||= User.new # guest user (not logged in)
+    user ||= User.new
 
     if user.admin?
       can :manage, :all
@@ -12,31 +12,38 @@ class Ability
     end
 
     # --- Projects ---
-    # Anyone can read public projects
     can :read, Project, is_public: true
-
-    if user.persisted?
-      can :create, Project
-
-      # Members (any role) can read projects they belong to
-      can :read, Project do |project|
-        project.project_members.exists?(user: user)
-      end
-
-      # Owners can update, destroy, and manage members
-      can [ :update, :destroy, :manage_members ], Project do |project|
-        project.project_members.exists?(user: user, role: "owner")
-      end
-    end
 
     # --- Collections ---
     can :read, Collection, is_public: true
 
+    # --- CoreFiles ---
+    can :read, CoreFile, is_public: true
+
     if user.persisted?
-      can :read, Collection do |collection|
-        member = collection.project.project_members.find_by(user: user)
-        member&.scoped_to?(collection)
+      can :create, Project
+      can :read, Project, project_members: { user_id: user.id }
+      can [ :update, :destroy, :manage_members ], Project do |project|
+        project.project_members.exists?(user: user, role: "owner")
       end
+
+      # Arrays (pluck) so CanCan can match against instances as well as generate SQL.
+      # Project-wide members have no collection scopes; scoped members have at least one.
+      project_wide_project_ids = ProjectMember
+        .left_joins(:collection_scopes)
+        .where(user: user)
+        .where(project_member_collection_scopes: { id: nil })
+        .pluck(:project_id)
+
+      scoped_collection_ids = ProjectMemberCollectionScope
+        .joins(:project_member)
+        .where(project_members: { user_id: user.id })
+        .pluck(:collection_id)
+
+      # Project-wide members can read any collection in their project.
+      # Scoped members can additionally read their explicitly assigned collections.
+      can :read, Collection, project_id: project_wide_project_ids if project_wide_project_ids.any?
+      can :read, Collection, id: scoped_collection_ids if scoped_collection_ids.any?
 
       can :create, Collection do |collection|
         collection.project&.project_members&.exists?(user: user, role: "owner")
@@ -45,34 +52,20 @@ class Ability
       can [ :update, :destroy ], Collection do |collection|
         collection.project.project_members.exists?(user: user, role: "owner")
       end
-    end
 
-    # --- CoreFiles ---
-    can :read, CoreFile, is_public: true
+      # Same scoping pattern for CoreFiles.
+      can :read, CoreFile, collections: { project_id: project_wide_project_ids } if project_wide_project_ids.any?
+      can :read, CoreFile, collections: { id: scoped_collection_ids } if scoped_collection_ids.any?
 
-    if user.persisted?
-      can :read, CoreFile do |core_file|
-        project = core_file.project
-        member = project&.project_members&.find_by(user: user)
-        next false unless member
-        member.project_wide? || core_file.collections.any? { |c| member.collection_scopes.exists?(collection: c) }
-      end
-
-      # Fine-grained create authorization (depositor must be project member)
-      # is enforced by the model's depositor_is_project_member validation
       can :create, CoreFile
 
-      can :update, CoreFile do |core_file|
-        core_file.project&.project_members&.exists?(user: user)
-      end
+      can :update, CoreFile, collections: { project: { project_members: { user_id: user.id } } }
 
       can :destroy, CoreFile do |core_file|
         core_file.project&.project_members&.exists?(user: user, role: "owner")
       end
-    end
 
-    # --- ImageFiles ---
-    if user.persisted?
+      # --- ImageFiles ---
       can [ :create, :destroy ], ImageFile do |image_file|
         case image_file.imageable_type
         when "User"
@@ -87,17 +80,13 @@ class Ability
             image_file.imageable&.project&.project_members&.exists?(user: user, role: "owner")
         end
       end
-    end
 
-    # --- CollectionCoreFiles ---
-    if user.persisted?
+      # --- CollectionCoreFiles ---
       can [ :create, :destroy ], CollectionCoreFile do |ccf|
         ccf.collection&.project&.project_members&.exists?(user: user)
       end
-    end
 
-    # --- Users ---
-    if user.persisted?
+      # --- Users ---
       can [ :edit, :update ], User, id: user.id
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -4,8 +4,7 @@ class Ability
   include CanCan::Ability
 
   def initialize(user)
-    # User.new is not persisted, so guest users fall through all persisted? guards below
-    user ||= User.new
+    user ||= User.new # guest user (not logged in)
 
     if user.admin?
       can :manage, :all
@@ -19,9 +18,10 @@ class Ability
     if user.persisted?
       can :create, Project
 
-      # Members (any role) can read projects they belong to.
-      # Hash condition (not a block) so accessible_by can translate it to SQL.
-      can :read, Project, project_members: { user_id: user.id }
+      # Members (any role) can read projects they belong to
+      can :read, Project do |project|
+        project.project_members.exists?(user: user)
+      end
 
       # Owners can update, destroy, and manage members
       can [ :update, :destroy, :manage_members ], Project do |project|
@@ -33,7 +33,10 @@ class Ability
     can :read, Collection, is_public: true
 
     if user.persisted?
-      can :read, Collection, project: { project_members: { user_id: user.id } }
+      can :read, Collection do |collection|
+        member = collection.project.project_members.find_by(user: user)
+        member&.scoped_to?(collection)
+      end
 
       can :create, Collection do |collection|
         collection.project&.project_members&.exists?(user: user, role: "owner")
@@ -48,26 +51,54 @@ class Ability
     can :read, CoreFile, is_public: true
 
     if user.persisted?
-      can :read, CoreFile, collections: { project: { project_members: { user_id: user.id } } }
+      can :read, CoreFile do |core_file|
+        project = core_file.project
+        member = project&.project_members&.find_by(user: user)
+        next false unless member
+        member.project_wide? || core_file.collections.any? { |c| member.collection_scopes.exists?(collection: c) }
+      end
 
       # Fine-grained create authorization (depositor must be project member)
       # is enforced by the model's depositor_is_project_member validation
       can :create, CoreFile
 
-      can :update, CoreFile, collections: { project: { project_members: { user_id: user.id } } }
+      can :update, CoreFile do |core_file|
+        core_file.project&.project_members&.exists?(user: user)
+      end
 
-      # TODO: The spec notes contributors can set configurations for their own records
-      # (e.g. default view package), which implies the depositor may have field-level
-      # permissions beyond what other members have. Flagged for Strategy Group review
-      # before implementing per-field update scoping.
       can :destroy, CoreFile do |core_file|
         core_file.project&.project_members&.exists?(user: user, role: "owner")
       end
     end
 
+    # --- ImageFiles ---
+    if user.persisted?
+      can [ :create, :destroy ], ImageFile do |image_file|
+        case image_file.imageable_type
+        when "User"
+          image_file.imageable_id == user.id
+        when "Project"
+          image_file.imageable&.project_members&.exists?(user: user, role: "owner")
+        when "Collection"
+          image_file.imageable&.depositor == user ||
+            image_file.imageable&.project&.project_members&.exists?(user: user, role: "owner")
+        when "CoreFile"
+          image_file.imageable&.depositor == user ||
+            image_file.imageable&.project&.project_members&.exists?(user: user, role: "owner")
+        end
+      end
+    end
+
+    # --- CollectionCoreFiles ---
+    if user.persisted?
+      can [ :create, :destroy ], CollectionCoreFile do |ccf|
+        ccf.collection&.project&.project_members&.exists?(user: user)
+      end
+    end
+
     # --- Users ---
     if user.persisted?
-      can :update, User, id: user.id
+      can [ :edit, :update ], User, id: user.id
     end
   end
 end

--- a/app/models/project_member.rb
+++ b/app/models/project_member.rb
@@ -5,8 +5,17 @@ class ProjectMember < ApplicationRecord
   # associations
   belongs_to :project
   belongs_to :user
+  has_many :collection_scopes, class_name: "ProjectMemberCollectionScope", dependent: :destroy
 
   # validations
   validates :user, uniqueness: { scope: :project }
   validates :role, inclusion: { in: ROLES, message: "%{value} is not a valid role" }
+
+  def project_wide?
+    collection_scopes.none?
+  end
+
+  def scoped_to?(collection)
+    project_wide? || collection_scopes.exists?(collection: collection)
+  end
 end

--- a/app/models/project_member_collection_scope.rb
+++ b/app/models/project_member_collection_scope.rb
@@ -1,0 +1,14 @@
+class ProjectMemberCollectionScope < ApplicationRecord
+  belongs_to :project_member
+  belongs_to :collection
+
+  validates :collection, uniqueness: { scope: :project_member }
+  validate :owner_cannot_be_scoped
+
+  private
+
+  def owner_cannot_be_scoped
+    return unless project_member&.role == "owner"
+    errors.add(:base, "owners cannot be scoped to a specific collection")
+  end
+end

--- a/db/migrate/20260421161258_create_project_member_collection_scopes.rb
+++ b/db/migrate/20260421161258_create_project_member_collection_scopes.rb
@@ -1,0 +1,13 @@
+class CreateProjectMemberCollectionScopes < ActiveRecord::Migration[8.1]
+  def change
+    create_table :project_member_collection_scopes do |t|
+      t.references :project_member, null: false, foreign_key: true
+      t.references :collection, null: false, foreign_key: true
+      t.timestamps
+    end
+    add_index :project_member_collection_scopes,
+              [ :project_member_id, :collection_id ],
+              unique: true,
+              name: "index_pmcs_on_project_member_and_collection"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -95,6 +95,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_180203) do
     t.index ["imageable_type", "imageable_id"], name: "index_image_files_on_imageable_type_and_imageable_id"
   end
 
+  create_table "project_member_collection_scopes", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "collection_id", null: false
+    t.datetime "created_at", null: false
+    t.bigint "project_member_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["collection_id"], name: "index_project_member_collection_scopes_on_collection_id"
+    t.index ["project_member_id", "collection_id"], name: "index_pmcs_on_project_member_and_collection", unique: true
+    t.index ["project_member_id"], name: "index_project_member_collection_scopes_on_project_member_id"
+  end
+
   create_table "project_members", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.boolean "is_project_depositor"
@@ -161,4 +171,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_180203) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "collection_core_files", "collections"
   add_foreign_key "collection_core_files", "core_files"
+  add_foreign_key "project_member_collection_scopes", "collections"
+  add_foreign_key "project_member_collection_scopes", "project_members"
 end

--- a/spec/factories/project_member_collection_scopes.rb
+++ b/spec/factories/project_member_collection_scopes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :project_member_collection_scope do
+    association :project_member
+    association :collection
+  end
+end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -19,22 +19,6 @@ RSpec.describe Ability, type: :model do
   let(:other_owner) { create(:user) }
   let(:other_project) { create(:project, depositor: other_owner, is_public: false) }
 
-  # ImageFile helpers — build unsaved records with imageable set so ability block can inspect imageable_type
-  def user_image_file(for_user)
-    build(:image_file, imageable: for_user, depositor: for_user)
-  end
-
-  def project_image_file(for_project)
-    build(:image_file, imageable: for_project, depositor: for_project.depositor)
-  end
-
-  def collection_image_file(for_collection)
-    build(:image_file, imageable: for_collection, depositor: for_collection.depositor)
-  end
-
-  def core_file_image_file(for_core_file)
-    build(:image_file, imageable: for_core_file, depositor: for_core_file.depositor)
-  end
 
   context "as a guest" do
     let(:user) { nil }
@@ -64,10 +48,6 @@ RSpec.describe Ability, type: :model do
     # Users
     it { is_expected.not_to be_able_to(:edit, owner) }
     it { is_expected.not_to be_able_to(:update, owner) }
-
-    # ImageFiles — guests cannot manage any
-    it { is_expected.not_to be_able_to(:create, user_image_file(owner)) }
-    it { is_expected.not_to be_able_to(:destroy, user_image_file(owner)) }
   end
 
   context "as a logged-in non-member" do
@@ -100,14 +80,6 @@ RSpec.describe Ability, type: :model do
     it { is_expected.to be_able_to(:update, user) }
     it { is_expected.not_to be_able_to(:edit, owner) }
     it { is_expected.not_to be_able_to(:update, owner) }
-
-    # ImageFiles — can manage own avatar; cannot manage others' resources
-    it { is_expected.to be_able_to(:create, user_image_file(user)) }
-    it { is_expected.to be_able_to(:destroy, user_image_file(user)) }
-    it { is_expected.not_to be_able_to(:create, user_image_file(owner)) }
-    it { is_expected.not_to be_able_to(:create, project_image_file(public_project)) }
-    it { is_expected.not_to be_able_to(:create, collection_image_file(public_collection)) }
-    it { is_expected.not_to be_able_to(:create, core_file_image_file(public_core_file)) }
   end
 
   context "as a project contributor" do
@@ -171,6 +143,7 @@ RSpec.describe Ability, type: :model do
 
   context "as a project owner" do
     let(:user) { owner }
+    before { public_project }
 
     # Projects — own projects fully manageable
     it { is_expected.to be_able_to(:read, public_project) }
@@ -203,18 +176,6 @@ RSpec.describe Ability, type: :model do
     it { is_expected.to be_able_to(:update, owner) }
     it { is_expected.not_to be_able_to(:edit, other_owner) }
     it { is_expected.not_to be_able_to(:update, other_owner) }
-
-    # ImageFiles — own avatar, own project/collection/core_file thumbnails
-    it { is_expected.to be_able_to(:create, user_image_file(owner)) }
-    it { is_expected.to be_able_to(:destroy, user_image_file(owner)) }
-    it { is_expected.to be_able_to(:create, project_image_file(public_project)) }
-    it { is_expected.to be_able_to(:destroy, project_image_file(public_project)) }
-    it { is_expected.to be_able_to(:create, collection_image_file(public_collection)) }
-    it { is_expected.to be_able_to(:destroy, collection_image_file(public_collection)) }
-    it { is_expected.to be_able_to(:create, core_file_image_file(public_core_file)) }
-    it { is_expected.to be_able_to(:destroy, core_file_image_file(public_core_file)) }
-    it { is_expected.not_to be_able_to(:create, project_image_file(other_project)) }
-    it { is_expected.not_to be_able_to(:destroy, project_image_file(other_project)) }
   end
 
   context "as an admin" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -19,6 +19,23 @@ RSpec.describe Ability, type: :model do
   let(:other_owner) { create(:user) }
   let(:other_project) { create(:project, depositor: other_owner, is_public: false) }
 
+  # ImageFile helpers — build unsaved records with imageable set so ability block can inspect imageable_type
+  def user_image_file(for_user)
+    build(:image_file, imageable: for_user, depositor: for_user)
+  end
+
+  def project_image_file(for_project)
+    build(:image_file, imageable: for_project, depositor: for_project.depositor)
+  end
+
+  def collection_image_file(for_collection)
+    build(:image_file, imageable: for_collection, depositor: for_collection.depositor)
+  end
+
+  def core_file_image_file(for_core_file)
+    build(:image_file, imageable: for_core_file, depositor: for_core_file.depositor)
+  end
+
   context "as a guest" do
     let(:user) { nil }
 
@@ -47,6 +64,10 @@ RSpec.describe Ability, type: :model do
     # Users
     it { is_expected.not_to be_able_to(:edit, owner) }
     it { is_expected.not_to be_able_to(:update, owner) }
+
+    # ImageFiles — guests cannot manage any
+    it { is_expected.not_to be_able_to(:create, user_image_file(owner)) }
+    it { is_expected.not_to be_able_to(:destroy, user_image_file(owner)) }
   end
 
   context "as a logged-in non-member" do
@@ -79,6 +100,14 @@ RSpec.describe Ability, type: :model do
     it { is_expected.to be_able_to(:update, user) }
     it { is_expected.not_to be_able_to(:edit, owner) }
     it { is_expected.not_to be_able_to(:update, owner) }
+
+    # ImageFiles — can manage own avatar; cannot manage others' resources
+    it { is_expected.to be_able_to(:create, user_image_file(user)) }
+    it { is_expected.to be_able_to(:destroy, user_image_file(user)) }
+    it { is_expected.not_to be_able_to(:create, user_image_file(owner)) }
+    it { is_expected.not_to be_able_to(:create, project_image_file(public_project)) }
+    it { is_expected.not_to be_able_to(:create, collection_image_file(public_collection)) }
+    it { is_expected.not_to be_able_to(:create, core_file_image_file(public_core_file)) }
   end
 
   context "as a project contributor" do
@@ -117,6 +146,29 @@ RSpec.describe Ability, type: :model do
     it { is_expected.not_to be_able_to(:destroy, public_core_file) }
   end
 
+  context "as a collection-scoped contributor" do
+    let(:user) { create(:user) }
+    let(:allowed_collection) { public_collection }
+    let(:off_limits_collection) { create(:collection, project: public_project, depositor: owner, is_public: false) }
+    let(:off_limits_core_file) { create(:core_file, depositor: owner, collections: [ off_limits_collection ], is_public: false) }
+
+    before do
+      member = create(:project_member, project: public_project, user: user, role: "contributor")
+      create(:project_member_collection_scope, project_member: member, collection: allowed_collection)
+    end
+
+    # Collections — can read allowed collection; cannot read others in same project
+    it { is_expected.to be_able_to(:read, allowed_collection) }
+    it { is_expected.not_to be_able_to(:read, off_limits_collection) }
+
+    # Cannot create new collections — scoped contributors are not project-wide
+    it { is_expected.not_to be_able_to(:create, Collection.new(project: public_project)) }
+
+    # CoreFiles — can read files in allowed collection; not files in off-limits collections
+    it { is_expected.to be_able_to(:read, public_core_file) }
+    it { is_expected.not_to be_able_to(:read, off_limits_core_file) }
+  end
+
   context "as a project owner" do
     let(:user) { owner }
 
@@ -151,6 +203,18 @@ RSpec.describe Ability, type: :model do
     it { is_expected.to be_able_to(:update, owner) }
     it { is_expected.not_to be_able_to(:edit, other_owner) }
     it { is_expected.not_to be_able_to(:update, other_owner) }
+
+    # ImageFiles — own avatar, own project/collection/core_file thumbnails
+    it { is_expected.to be_able_to(:create, user_image_file(owner)) }
+    it { is_expected.to be_able_to(:destroy, user_image_file(owner)) }
+    it { is_expected.to be_able_to(:create, project_image_file(public_project)) }
+    it { is_expected.to be_able_to(:destroy, project_image_file(public_project)) }
+    it { is_expected.to be_able_to(:create, collection_image_file(public_collection)) }
+    it { is_expected.to be_able_to(:destroy, collection_image_file(public_collection)) }
+    it { is_expected.to be_able_to(:create, core_file_image_file(public_core_file)) }
+    it { is_expected.to be_able_to(:destroy, core_file_image_file(public_core_file)) }
+    it { is_expected.not_to be_able_to(:create, project_image_file(other_project)) }
+    it { is_expected.not_to be_able_to(:destroy, project_image_file(other_project)) }
   end
 
   context "as an admin" do
@@ -162,4 +226,41 @@ RSpec.describe Ability, type: :model do
     it { is_expected.to be_able_to(:manage, public_core_file) }
     it { is_expected.to be_able_to(:manage, owner) }
   end
+
+  # accessible_by scope tests — only hash-condition rules translate to SQL.
+  # Block-based rules (used for member/owner checks) cannot be converted and are
+  # not used with accessible_by in the app; controllers use custom scoping helpers.
+  describe "accessible_by scopes" do
+    before do
+      public_project
+      private_project
+      public_collection
+      private_collection
+      public_core_file
+      private_core_file
+    end
+
+    context "as a guest" do
+      let(:user) { nil }
+
+      it "returns only public projects" do
+        expect(Project.accessible_by(ability)).to contain_exactly(public_project)
+      end
+
+      it "returns only public collections" do
+        expect(Collection.accessible_by(ability)).to contain_exactly(public_collection)
+      end
+
+      it "returns only public core files" do
+        expect(CoreFile.accessible_by(ability)).to contain_exactly(public_core_file)
+      end
+    end
+  end
+
+  # ProjectMember authorization note:
+  # There are no direct CanCanCan rules for ProjectMember create/read/update/destroy.
+  # ProjectMember management is authorized via the parent Project's :manage_members
+  # permission, checked in ProjectMembersController with:
+  #   authorize! :manage_members, @project
+  # This means admins and project owners can manage members; all others cannot.
 end

--- a/spec/models/project_member_collection_scope_spec.rb
+++ b/spec/models/project_member_collection_scope_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProjectMemberCollectionScope, type: :model do
+  let(:owner) { create(:user) }
+  let(:project) { create(:project, depositor: owner) }
+  let(:collection) { create(:collection, project: project, depositor: owner) }
+  let(:contributor) { create(:user) }
+  let(:contributor_member) { create(:project_member, project: project, user: contributor, role: "contributor") }
+  let(:owner_member) { project.project_members.find_by(user: owner, role: "owner") }
+
+  describe "associations" do
+    it { is_expected.to belong_to(:project_member) }
+    it { is_expected.to belong_to(:collection) }
+  end
+
+  describe "validations" do
+    it "is valid with a contributor member and a collection" do
+      scope = described_class.new(project_member: contributor_member, collection: collection)
+      expect(scope).to be_valid
+    end
+
+    it "enforces uniqueness of collection scoped to project_member" do
+      described_class.create!(project_member: contributor_member, collection: collection)
+      duplicate = described_class.new(project_member: contributor_member, collection: collection)
+      expect(duplicate).not_to be_valid
+      expect(duplicate.errors[:collection]).to be_present
+    end
+
+    it "prevents owners from being scoped" do
+      scope = described_class.new(project_member: owner_member, collection: collection)
+      expect(scope).not_to be_valid
+      expect(scope.errors[:base]).to include("owners cannot be scoped to a specific collection")
+    end
+  end
+
+  describe "ProjectMember#project_wide?" do
+    it "returns true when the member has no collection scopes" do
+      expect(contributor_member.project_wide?).to be true
+    end
+
+    it "returns false when the member has collection scopes" do
+      described_class.create!(project_member: contributor_member, collection: collection)
+      expect(contributor_member.project_wide?).to be false
+    end
+  end
+
+  describe "ProjectMember#scoped_to?" do
+    let(:other_collection) { create(:collection, project: project, depositor: owner) }
+
+    it "returns true for a project-wide member regardless of collection" do
+      expect(contributor_member.scoped_to?(collection)).to be true
+      expect(contributor_member.scoped_to?(other_collection)).to be true
+    end
+
+    it "returns true for the allowed collection when scoped" do
+      described_class.create!(project_member: contributor_member, collection: collection)
+      expect(contributor_member.scoped_to?(collection)).to be true
+    end
+
+    it "returns false for a non-allowed collection when scoped" do
+      described_class.create!(project_member: contributor_member, collection: collection)
+      expect(contributor_member.scoped_to?(other_collection)).to be false
+    end
+  end
+end

--- a/spec/requests/project_members_spec.rb
+++ b/spec/requests/project_members_spec.rb
@@ -45,6 +45,26 @@ RSpec.describe "ProjectMembers", type: :request do
           expect(response).to have_http_status(:unprocessable_content)
         end
       end
+
+      context "with collection_ids" do
+        let(:collection) { create(:collection, project: project, depositor: owner) }
+
+        it "creates collection scopes for a contributor" do
+          post project_project_members_path(project),
+               params: { project_member: { user_id: other_user.id, role: "contributor" },
+                         collection_ids: [ collection.id ] }
+          member = ProjectMember.find_by(project: project, user: other_user)
+          expect(member.collection_scopes.pluck(:collection_id)).to contain_exactly(collection.id)
+        end
+
+        it "ignores collection_ids for an owner" do
+          post project_project_members_path(project),
+               params: { project_member: { user_id: other_user.id, role: "owner" },
+                         collection_ids: [ collection.id ] }
+          member = ProjectMember.find_by(project: project, user: other_user)
+          expect(member.collection_scopes).to be_empty
+        end
+      end
     end
 
     context "when signed in as a non-owner" do
@@ -84,6 +104,28 @@ RSpec.describe "ProjectMembers", type: :request do
       it "returns ok status" do
         patch project_project_member_path(project, contributor_member), params: update_params
         expect(response).to have_http_status(:ok)
+      end
+
+      context "replacing collection scopes" do
+        let(:collection_a) { create(:collection, project: project, depositor: owner) }
+        let(:collection_b) { create(:collection, project: project, depositor: owner) }
+
+        before do
+          contributor_member.collection_scopes.create!(collection: collection_a)
+        end
+
+        it "replaces existing scopes when collection_ids is provided" do
+          patch project_project_member_path(project, contributor_member),
+                params: { collection_ids: [ collection_b.id ] }
+          expect(contributor_member.reload.collection_scopes.pluck(:collection_id))
+            .to contain_exactly(collection_b.id)
+        end
+
+        it "clears all scopes when collection_ids is an empty array" do
+          patch project_project_member_path(project, contributor_member),
+                params: { collection_ids: [] }
+          expect(contributor_member.reload.collection_scopes).to be_empty
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

- Adds `ProjectMemberCollectionScope` join table and model, allowing project owners to restrict a contributor's access to specific collections
- `ProjectMember` gains `project_wide?` and `scoped_to?(collection)` helpers
- `ProjectMembersController` accepts a `collection_ids` param to set or replace scopes on create/update
- Ability rules enforce that scoped contributors cannot read private collections or core files outside their assigned collections

## Notes

Scoped access restricts both read and write for project members. The read restriction is implemented via pluck-based ID arrays in the ability initializer, so rules stay SQL-compatible with `accessible_by`. Unauthenticated visitors and non-members are governed entirely by the `is_public` rules. `ImageFile` ability rules are present but untested here — those specs land in the `ImageFiles` PR.

## Test plan

- [ ] Run migrations: `rails db:migrate`
- [ ] Run full test suite