### PR TITLE
Add CollectionCoreFiles and ImageFiles controllers

### DIFF
--- a/app/controllers/collection_core_files_controller.rb
+++ b/app/controllers/collection_core_files_controller.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class CollectionCoreFilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_collection
+  before_action :set_collection_core_file, only: [ :destroy ]
+
+  def create
+    core_file = CoreFile.find(params[:core_file_id])
+    @collection_core_file = CollectionCoreFile.new(collection: @collection, core_file: core_file)
+    authorize! :create, @collection_core_file
+
+    if @collection_core_file.save
+      render json: @collection_core_file, status: :created
+    else
+      render json: { errors: @collection_core_file.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    authorize! :destroy, @collection_core_file
+    @collection_core_file.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_collection
+    @collection = Collection.find(params[:collection_id])
+  end
+
+  def set_collection_core_file
+    @collection_core_file = @collection.collection_core_files.find(params[:id])
+  end
+end

--- a/app/controllers/image_files_controller.rb
+++ b/app/controllers/image_files_controller.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+class ImageFilesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_imageable
+
+  def create
+    existing = @imageable.image_file
+    @image_file = ImageFile.new(image_file_params.merge(imageable: @imageable, depositor: current_user))
+    authorize! :create, @image_file
+
+    existing&.destroy
+
+    if @image_file.save
+      render json: @image_file, status: :created
+    else
+      render json: { errors: @image_file.errors.full_messages }, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    @image_file = @imageable.image_file
+    raise ActiveRecord::RecordNotFound unless @image_file
+    authorize! :destroy, @image_file
+    @image_file.destroy
+    head :no_content
+  end
+
+  private
+
+  def set_imageable
+    @imageable = if params[:user_id]
+      User.find(params[:user_id])
+    elsif params[:project_id]
+      Project.find(params[:project_id])
+    elsif params[:collection_id]
+      Collection.find(params[:collection_id])
+    elsif params[:core_file_id]
+      CoreFile.find(params[:core_file_id])
+    end
+  end
+
+  def image_file_params
+    params.require(:image_file).permit(:title, :alt_text, :image_url, :file)
+  end
+end

--- a/app/models/image_file.rb
+++ b/app/models/image_file.rb
@@ -1,5 +1,6 @@
 class ImageFile < ApplicationRecord
   # associations
+  belongs_to :depositor, class_name: "User"
   belongs_to :imageable, polymorphic: true
   has_one_attached :file
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,10 +31,18 @@ Rails.application.routes.draw do
 
   resources :projects do
     resources :project_members, only: [ :create, :update, :destroy ]
+    resource :image_file, only: [ :create, :destroy ], controller: "image_files"
   end
-  resources :users, only: [ :show, :edit, :update ]
-  resources :collections
-  resources :core_files
+  resources :users, only: [ :show, :edit, :update ] do
+    resource :image_file, only: [ :create, :destroy ], controller: "image_files"
+  end
+  resources :collections do
+    resources :collection_core_files, only: [ :create, :destroy ]
+    resource :image_file, only: [ :create, :destroy ], controller: "image_files"
+  end
+  resources :core_files do
+    resource :image_file, only: [ :create, :destroy ], controller: "image_files"
+  end
 
   get "up" => "rails/health#show", as: :rails_health_check
 

--- a/spec/factories/image_files.rb
+++ b/spec/factories/image_files.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :image_file do
     sequence(:title) { |n| "Test Image #{n}" }
-    depositor_id { create(:user).id }
+    association :depositor, factory: :user
     association :imageable, factory: :core_file
     image_url { "https://example.com/image.jpg" }
     file_format { "jpg" }

--- a/spec/models/image_file_spec.rb
+++ b/spec/models/image_file_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe ImageFile, type: :model do
   end
 
   describe 'associations' do
+    it { is_expected.to belong_to(:depositor) }
     it { is_expected.to belong_to(:imageable) }
   end
 

--- a/spec/requests/collection_core_files_spec.rb
+++ b/spec/requests/collection_core_files_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "CollectionCoreFiles", type: :request do
+  let(:owner) { create(:user) }
+  let(:non_member) { create(:user) }
+  let(:project) { create(:project, depositor: owner) }
+  let(:collection) { create(:collection, project: project, depositor: owner) }
+  let(:core_file) { create(:core_file, depositor: owner, collections: [ collection ]) }
+
+  describe "POST /collections/:collection_id/collection_core_files" do
+    let(:other_collection) { create(:collection, project: project, depositor: owner) }
+
+    context "when not signed in" do
+      it "redirects to sign in" do
+        post collection_collection_core_files_path(other_collection), params: { core_file_id: core_file.id }
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "as a project member" do
+      before { core_file; sign_in owner }
+
+      it "creates the association" do
+        expect {
+          post collection_collection_core_files_path(other_collection),
+               params: { core_file_id: core_file.id }, as: :json
+        }.to change(CollectionCoreFile, :count).by(1)
+      end
+
+      it "returns created status" do
+        post collection_collection_core_files_path(other_collection),
+             params: { core_file_id: core_file.id }, as: :json
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "as a non-member" do
+      before { core_file; sign_in non_member }
+
+      it "returns forbidden" do
+        post collection_collection_core_files_path(collection),
+             params: { core_file_id: core_file.id }, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not create the association" do
+        expect {
+          post collection_collection_core_files_path(collection),
+               params: { core_file_id: core_file.id }, as: :json
+        }.not_to change(CollectionCoreFile, :count)
+      end
+    end
+
+    context "with a core file from a different project" do
+      let(:other_project) { create(:project, depositor: owner) }
+      let(:other_project_collection) { create(:collection, project: other_project, depositor: owner) }
+      let(:other_project_core_file) { create(:core_file, depositor: owner, collections: [ other_project_collection ]) }
+
+      before { other_project_core_file; sign_in owner }
+
+      it "returns unprocessable entity" do
+        post collection_collection_core_files_path(collection),
+             params: { core_file_id: other_project_core_file.id }, as: :json
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "returns an error message" do
+        post collection_collection_core_files_path(collection),
+             params: { core_file_id: other_project_core_file.id }, as: :json
+        expect(JSON.parse(response.body)["errors"]).to be_present
+      end
+
+      it "does not create the association" do
+        expect {
+          post collection_collection_core_files_path(collection),
+               params: { core_file_id: other_project_core_file.id }, as: :json
+        }.not_to change(CollectionCoreFile, :count)
+      end
+    end
+  end
+
+  describe "DELETE /collections/:collection_id/collection_core_files/:id" do
+    let(:association) { CollectionCoreFile.find_by!(collection: collection, core_file: core_file) }
+
+    before { core_file } # ensure core_file (and its association) is created
+
+    context "when not signed in" do
+      it "redirects to sign in" do
+        delete collection_collection_core_file_path(collection, association)
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "as a project member" do
+      before { sign_in owner }
+
+      it "destroys the association" do
+        expect {
+          delete collection_collection_core_file_path(collection, association), as: :json
+        }.to change(CollectionCoreFile, :count).by(-1)
+      end
+
+      it "returns no content status" do
+        delete collection_collection_core_file_path(collection, association), as: :json
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "as a non-member" do
+      before { sign_in non_member }
+
+      it "returns forbidden" do
+        delete collection_collection_core_file_path(collection, association), as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not destroy the association" do
+        expect {
+          delete collection_collection_core_file_path(collection, association), as: :json
+        }.not_to change(CollectionCoreFile, :count)
+      end
+    end
+  end
+end

--- a/spec/requests/image_files_spec.rb
+++ b/spec/requests/image_files_spec.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "ImageFiles", type: :request do
+  let(:owner) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:project) { create(:project, depositor: owner) }
+  let(:collection) { create(:collection, project: project, depositor: owner) }
+  let(:core_file) { create(:core_file, depositor: owner, collections: [ collection ]) }
+  let(:valid_params) { { image_file: { title: "Thumbnail", alt_text: "An image", image_url: "https://example.com/img.jpg" } } }
+
+  shared_examples "requires authentication" do |method, path_helper|
+    it "redirects to sign in" do
+      send(method, send(path_helper), params: valid_params)
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+
+  describe "User avatar (POST /users/:user_id/image_file)" do
+    context "when not signed in" do
+      it "redirects to sign in" do
+        post user_image_file_path(owner), params: valid_params
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "as the user themselves" do
+      before { sign_in owner }
+
+      it "creates the image file" do
+        post user_image_file_path(owner), params: valid_params, as: :json
+        expect(response).to have_http_status(:created)
+      end
+
+      it "replaces an existing image file" do
+        owner.create_image_file!(title: "Old", image_url: "https://example.com/old.jpg", depositor: owner)
+        expect {
+          post user_image_file_path(owner), params: valid_params, as: :json
+        }.not_to change(ImageFile, :count)
+        expect(owner.reload.image_file.title).to eq("Thumbnail")
+      end
+    end
+
+    context "as another user" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        post user_image_file_path(owner), params: valid_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "User avatar (DELETE /users/:user_id/image_file)" do
+    before { owner.create_image_file!(title: "Avatar", image_url: "https://example.com/img.jpg", depositor: owner) }
+
+    context "as the user themselves" do
+      before { sign_in owner }
+
+      it "destroys the image file" do
+        expect {
+          delete user_image_file_path(owner), as: :json
+        }.to change(ImageFile, :count).by(-1)
+      end
+
+      it "returns no content" do
+        delete user_image_file_path(owner), as: :json
+        expect(response).to have_http_status(:no_content)
+      end
+    end
+
+    context "as another user" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        delete user_image_file_path(owner), as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "Project thumbnail (POST /projects/:project_id/image_file)" do
+    context "as the project owner" do
+      before { sign_in owner }
+
+      it "creates the image file" do
+        post project_image_file_path(project), params: valid_params, as: :json
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "as a non-owner" do
+      before do
+        create(:project_member, project: project, user: other_user, role: "contributor")
+        sign_in other_user
+      end
+
+      it "returns forbidden" do
+        post project_image_file_path(project), params: valid_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+
+    context "as a non-member" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        post project_image_file_path(project), params: valid_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "Collection thumbnail (POST /collections/:collection_id/image_file)" do
+    context "as the collection depositor" do
+      before { sign_in owner }
+
+      it "creates the image file" do
+        post collection_image_file_path(collection), params: valid_params, as: :json
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "as a non-member" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        post collection_image_file_path(collection), params: valid_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+
+  describe "CoreFile thumbnail (POST /core_files/:core_file_id/image_file)" do
+    before { core_file }
+
+    context "as the core file depositor" do
+      before { sign_in owner }
+
+      it "creates the image file" do
+        post core_file_image_file_path(core_file), params: valid_params, as: :json
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context "as a non-member" do
+      before { sign_in other_user }
+
+      it "returns forbidden" do
+        post core_file_image_file_path(core_file), params: valid_params, as: :json
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

**CollectionCoreFilesController**
- Adds `create` and `destroy` actions for managing which core files belong to which collections
- Nested under collections
- Authorization requires project membership; cross-project joins are rejected with 422

**ImageFilesController**
- Adds `create` and `destroy` for image files attached polymorphically to `User`, `Project`, `Collection`, or `CoreFile`
- Replacing an existing image on create is handled automatically
- Ability rules enforce: self-only for user image files, owner-only for project image files, depositor-or-owner for collection and core file image files

## Test plan

- [ ] Run full test suite