### PR TITLE
Add TapasXq::RetrievalService for fetching stored TEI, MODS, and TFE files

### DIFF
--- a/app/services/tapas_xq/retrieval_service.rb
+++ b/app/services/tapas_xq/retrieval_service.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module TapasXq
+  # Service for retrieving TEI, MODS, and TFE files from TAPAS-XQ
+  # Useful for debugging, syncing, and displaying stored content
+  class RetrievalService
+    attr_reader :client, :project_id, :doc_id
+
+    # @param project_id [String, Integer] The project ID
+    # @param doc_id [String, Integer] The document ID
+    # @param client [TapasXq::Client, nil] Optional client for testing
+    def initialize(project_id, doc_id, client: nil)
+      @project_id = project_id
+      @doc_id = doc_id
+      @client = client || TapasXq::Client.new
+    end
+
+    # Retrieve the TEI file from TAPAS-XQ
+    # @return [String] TEI XML content
+    # @raise [TapasXq::Error] On API failure
+    def retrieve_tei
+      client.get("/#{project_id}/#{doc_id}/tei")
+    end
+
+    # Retrieve the MODS metadata from TAPAS-XQ
+    # @return [String] MODS XML content
+    # @raise [TapasXq::Error] On API failure
+    def retrieve_mods
+      client.get("/#{project_id}/#{doc_id}/mods")
+    end
+
+    # Retrieve the TFE (TAPAS-friendly environment) metadata from TAPAS-XQ
+    # @return [String] TFE XML content
+    # @raise [TapasXq::Error] On API failure
+    def retrieve_tfe
+      client.get("/#{project_id}/#{doc_id}/tfe")
+    end
+  end
+end

--- a/spec/services/tapas_xq/retrieval_service_spec.rb
+++ b/spec/services/tapas_xq/retrieval_service_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TapasXq::RetrievalService, type: :service do
+  let(:project_id) { 123 }
+  let(:doc_id) { 456 }
+  let(:service) { described_class.new(project_id, doc_id) }
+
+  describe '#retrieve_tei' do
+    it 'fetches TEI XML from TAPAS-XQ' do
+      tei_xml = "<TEI><teiHeader><title>Test Document</title></teiHeader></TEI>"
+      stub_tapas_xq_retrieve_tei(
+        project_id: project_id,
+        doc_id: doc_id,
+        tei_xml: tei_xml
+      )
+
+      result = service.retrieve_tei
+
+      expect(result).to eq(tei_xml)
+    end
+
+    it 'raises NotFoundError if TEI does not exist' do
+      stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/tei")
+        .to_return(status: 404, body: "Not Found")
+
+      expect {
+        service.retrieve_tei
+      }.to raise_error(TapasXq::NotFoundError)
+    end
+
+    it 'raises AuthenticationError on 401' do
+      stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/tei")
+        .to_return(status: 401, body: "Unauthorized")
+
+      expect {
+        service.retrieve_tei
+      }.to raise_error(TapasXq::AuthenticationError)
+    end
+
+    it 'raises ForbiddenError on 403' do
+      stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/tei")
+        .to_return(status: 403, body: "Forbidden")
+
+      expect {
+        service.retrieve_tei
+      }.to raise_error(TapasXq::ForbiddenError)
+    end
+
+    it 'raises ConnectionError on connection failure' do
+      stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/tei")
+        .to_raise(SocketError.new("Connection refused"))
+
+      expect {
+        service.retrieve_tei
+      }.to raise_error(TapasXq::ConnectionError)
+    end
+  end
+
+  describe '#retrieve_mods' do
+    it 'fetches MODS XML from TAPAS-XQ' do
+      mods_xml = "<mods><title>Test Document</title><author>John Doe</author></mods>"
+      stub_tapas_xq_retrieve_mods(
+        project_id: project_id,
+        doc_id: doc_id,
+        mods_xml: mods_xml
+      )
+
+      result = service.retrieve_mods
+
+      expect(result).to eq(mods_xml)
+    end
+
+    it 'raises NotFoundError if MODS does not exist' do
+      stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/mods")
+        .to_return(status: 404, body: "Not Found")
+
+      expect {
+        service.retrieve_mods
+      }.to raise_error(TapasXq::NotFoundError)
+    end
+
+    it 'raises ServerError on 500' do
+      stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/mods")
+        .to_return(status: 500, body: "Internal Server Error")
+
+      expect {
+        service.retrieve_mods
+      }.to raise_error(TapasXq::ServerError)
+    end
+  end
+
+  describe '#retrieve_tfe' do
+    it 'fetches TFE XML from TAPAS-XQ' do
+      tfe_xml = "<tfe><project>123</project><collections>coll1,coll2</collections></tfe>"
+      stub_tapas_xq_retrieve_tfe(
+        project_id: project_id,
+        doc_id: doc_id,
+        tfe_xml: tfe_xml
+      )
+
+      result = service.retrieve_tfe
+
+      expect(result).to eq(tfe_xml)
+    end
+
+    it 'raises NotFoundError if TFE does not exist' do
+      stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/tfe")
+        .to_return(status: 404, body: "Not Found")
+
+      expect {
+        service.retrieve_tfe
+      }.to raise_error(TapasXq::NotFoundError)
+    end
+
+    it 'raises TimeoutError on timeout' do
+      stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/tfe")
+        .to_timeout
+
+      expect {
+        service.retrieve_tfe
+      }.to raise_error(TapasXq::TimeoutError)
+    end
+  end
+
+  describe 'initialization' do
+    it 'accepts project_id and doc_id' do
+      expect(service.project_id).to eq(project_id)
+      expect(service.doc_id).to eq(doc_id)
+    end
+
+    it 'uses default client if none provided' do
+      expect(service.client).to be_a(TapasXq::Client)
+    end
+
+    it 'accepts custom client' do
+      custom_client = TapasXq::Client.new(base_url: 'http://custom.example.com')
+      custom_service = described_class.new(project_id, doc_id, client: custom_client)
+
+      expect(custom_service.client).to eq(custom_client)
+    end
+  end
+end

--- a/spec/support/tapas_xq_helpers.rb
+++ b/spec/support/tapas_xq_helpers.rb
@@ -7,7 +7,27 @@ module TapasXqHelpers
 
   def stub_tapas_xq_store(project_id:, doc_id:, mods_xml: "<mods/>")
     stub_request(:post, tapas_xq_url(project_id: project_id, doc_id: doc_id))
-      .to_return(status: 201, body: mods_xml)
+      .to_return(status: 201, body: mods_xml, headers: { 'Content-Type' => 'application/xml' })
+  end
+
+  def stub_tapas_xq_store_failure(project_id:, doc_id:, status: 500, body: "Internal Server Error")
+    stub_request(:post, tapas_xq_url(project_id: project_id, doc_id: doc_id))
+      .to_return(status: status, body: body)
+  end
+
+  def stub_tapas_xq_retrieve_tei(project_id:, doc_id:, tei_xml: "<TEI></TEI>")
+    stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/tei")
+      .to_return(status: 200, body: tei_xml, headers: { 'Content-Type' => 'application/xml' })
+  end
+
+  def stub_tapas_xq_retrieve_mods(project_id:, doc_id:, mods_xml: "<mods></mods>")
+    stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/mods")
+      .to_return(status: 200, body: mods_xml, headers: { 'Content-Type' => 'application/xml' })
+  end
+
+  def stub_tapas_xq_retrieve_tfe(project_id:, doc_id:, tfe_xml: "<tfe></tfe>")
+    stub_request(:get, "#{TapasXq.configuration.base_url}/#{project_id}/#{doc_id}/tfe")
+      .to_return(status: 200, body: tfe_xml, headers: { 'Content-Type' => 'application/xml' })
   end
 
   def stub_tapas_xq_connection_error(project_id:, doc_id:)
@@ -23,11 +43,6 @@ module TapasXqHelpers
   def stub_tapas_xq_auth_failure(project_id:, doc_id:)
     stub_request(:post, tapas_xq_url(project_id: project_id, doc_id: doc_id))
       .to_return(status: 401, body: "Unauthorized")
-  end
-
-  def stub_tapas_xq_store_failure(project_id:, doc_id:, status: 500)
-    stub_request(:post, tapas_xq_url(project_id: project_id, doc_id: doc_id))
-      .to_return(status: status, body: "Error")
   end
 end
 


### PR DESCRIPTION
## Summary

- Adds `TapasXq::RetrievalService` for retrieving stored TEI, MODS, and TFE
  files from the TAPAS-xq XML database
- This is the service the reading interface will use when a user requests a
  core file — the app fetches the stored TEI from TAPAS-xq and passes it
  through the eventual rendering pipeline
- Extends `spec/support/tapas_xq_helpers.rb` with retrieve stubs for all
  three file types

## Test plan

- [ ] All 14 retrieval service spec examples pass (`spec/services/tapas_xq/retrieval_service_spec.rb`)
- [ ] Covers success, 404, 403, 401, 500, timeout, and connection failure cases