### PR TITLE
Add description field to CoreFile Solr indexing

### DIFF
--- a/app/models/core_file.rb
+++ b/app/models/core_file.rb
@@ -69,6 +69,7 @@ class CoreFile < ApplicationRecord
     solr_doc["collections_ssim"] = collections.map(&:id)
     solr_doc["project_ssim"] = project.id
     solr_doc["title_info_title_ssi"] = title
+    solr_doc["description_tesim"] = description
     solr_doc["creator_tesim"] = tei_authors
     solr_doc["all_text_timv"] => nil # TODO: 'timv' is a datetime object datafield type in Solr, so it's unclear what this was intended to capture
     solr_doc["type_ssim"] = self.is_ography? ? self.ography_type : "TEI Record"

--- a/spec/models/core_file_spec.rb
+++ b/spec/models/core_file_spec.rb
@@ -343,6 +343,7 @@ RSpec.describe CoreFile, type: :model do
         depositor: depositor,
         collections: [ collection ],
         title: 'Solr Test Core File',
+        description: 'A test description',
         is_public: true,
         ography_type: nil
       )
@@ -358,9 +359,20 @@ RSpec.describe CoreFile, type: :model do
       expect(doc["collections_ssim"]).to eq(core_file.collections.map(&:id))
       expect(doc["project_ssim"]).to eq(project.id)
       expect(doc["title_info_title_ssi"]).to eq("Solr Test Core File")
+      expect(doc["description_tesim"]).to eq("A test description")
       expect(doc["type_ssim"]).to eq("TEI Record")
       expect(doc["access_ssim"]).to eq("public")
       expect(doc["image_file_ssi"]).to eq("public/assets/logo_no_text.png")
+    end
+
+    context 'when description is nil' do
+      let(:core_file) do
+        create(:core_file, depositor: depositor, collections: [ collection ], description: nil)
+      end
+
+      it 'sets description_tesim to nil' do
+        expect(core_file.to_solr["description_tesim"]).to be_nil
+      end
     end
 
     context 'when core file is an ography' do


### PR DESCRIPTION
## Summary
- Adds `description_tesim` to `CoreFile#to_solr` so the description field is included in Solr documents
- Extends the `#to_solr` model spec with populated and nil description cases

## Test plan
- [ ] `bundle exec rspec spec/models/core_file_spec.rb spec/requests/core_files_spec.rb`
- [ ] Confirm `description_tesim` appears in Solr documents for core files with a description
- [ ] Confirm `description_tesim` is nil in Solr documents for core files without a description