### PR TITLE
Rename service classes to domain nouns and fix public/private ordering

### DIFF
--- a/app/jobs/process_tei_file_job.rb
+++ b/app/jobs/process_tei_file_job.rb
@@ -36,7 +36,7 @@ class ProcessTeiFileJob < ApplicationJob
 
     core_file.update!(processing_status: "processing")
 
-    storage_service = TapasXq::StorageService.new(core_file)
+    storage_service = TapasXq::Storage.new(core_file)
     result = storage_service.store
 
     core_file.update!(

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -17,6 +17,20 @@ class Collection < ApplicationRecord
   # callbacks
   after_save :index_record
 
+  def to_solr(solr_doc = {})
+    solr_doc["active_record_model_ssi"] = self.class.to_s
+    solr_doc["depositor_tesim"] = depositor.id
+    solr_doc["table_id_ssi"] = id
+    solr_doc["id"] = "#{self.class}_#{id}"
+    solr_doc["edit_access_person_ssim"] = project.members["owner"].empty? ? depositor_id : project.owner[0].id
+    solr_doc["project_ssim"] = project.id
+    solr_doc["title_info_title_ssi"] = title
+    solr_doc["access_ssim"] = is_public ? "public" : "private"
+    solr_doc["image_file_ssi"] = "public/assets/logo_no_text.png" # this string will be replaced with S3 storage bucket url
+
+    solr_doc
+  end
+
   private
 
   def depositor_is_project_member
@@ -31,21 +45,5 @@ class Collection < ApplicationRecord
     unless project.is_public?
       errors.add(:is_public, "cannot be public when the project is private")
     end
-  end
-
-  public
-
-  def to_solr(solr_doc = {})
-    solr_doc["active_record_model_ssi"] = self.class.to_s
-    solr_doc["depositor_tesim"] = depositor.id
-    solr_doc["table_id_ssi"] = id
-    solr_doc["id"] = "#{self.class}_#{id}"
-    solr_doc["edit_access_person_ssim"] = project.members["owner"].empty? ? depositor_id : project.owner[0].id
-    solr_doc["project_ssim"] = project.id
-    solr_doc["title_info_title_ssi"] = title
-    solr_doc["access_ssim"] = is_public ? "public" : "private"
-    solr_doc["image_file_ssi"] = "public/assets/logo_no_text.png" # this string will be replaced with S3 storage bucket url
-
-    solr_doc
   end
 end

--- a/app/services/tapas_xq/retrieval.rb
+++ b/app/services/tapas_xq/retrieval.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module TapasXq
-  # Service for retrieving TEI, MODS, and TFE files from TAPAS-XQ
-  # Useful for debugging, syncing, and displaying stored content
-  class RetrievalService
+  # Retrieves TEI, MODS, and TFE files from TAPAS-XQ.
+  # Useful for debugging, syncing, and displaying stored content.
+  class Retrieval
     attr_reader :client, :project_id, :doc_id
 
     # @param project_id [String, Integer] The project ID

--- a/app/services/tapas_xq/storage.rb
+++ b/app/services/tapas_xq/storage.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module TapasXq
-  # Service for storing TEI files in TAPAS-XQ and generating MODS/TFE metadata
-  class StorageService
+  # Stores TEI files in TAPAS-XQ and generates MODS/TFE metadata.
+  class Storage
     attr_reader :client, :core_file
 
     # @param core_file [CoreFile] The core file to process

--- a/spec/jobs/process_tei_file_job_spec.rb
+++ b/spec/jobs/process_tei_file_job_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe ProcessTeiFileJob, type: :job do
       end
 
       it 'marks as failed on unexpected error' do
-        allow_any_instance_of(TapasXq::StorageService).to receive(:store).and_raise(StandardError, "Unexpected error")
+        allow_any_instance_of(TapasXq::Storage).to receive(:store).and_raise(StandardError, "Unexpected error")
 
         expect {
           described_class.perform_now(core_file.id)
@@ -101,7 +101,7 @@ RSpec.describe ProcessTeiFileJob, type: :job do
       end
 
       it 'logs unexpected errors' do
-        allow_any_instance_of(TapasXq::StorageService).to receive(:store).and_raise(RuntimeError, "Something went wrong")
+        allow_any_instance_of(TapasXq::Storage).to receive(:store).and_raise(RuntimeError, "Something went wrong")
 
         output = StringIO.new
         test_logger = ActiveSupport::Logger.new(output)

--- a/spec/services/tapas_xq/retrieval_spec.rb
+++ b/spec/services/tapas_xq/retrieval_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe TapasXq::RetrievalService, type: :service do
+RSpec.describe TapasXq::Retrieval, type: :service do
   let(:project_id) { 123 }
   let(:doc_id) { 456 }
   let(:service) { described_class.new(project_id, doc_id) }

--- a/spec/services/tapas_xq/storage_spec.rb
+++ b/spec/services/tapas_xq/storage_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe TapasXq::StorageService, type: :service do
+RSpec.describe TapasXq::Storage, type: :service do
   let(:depositor) { create(:user) }
   let(:project) { create(:project, depositor: depositor) }
   let(:collection) { create(:collection, project: project, depositor: depositor, is_public: true) }
@@ -216,9 +216,6 @@ RSpec.describe TapasXq::StorageService, type: :service do
       end
 
       it 'propagates ServerError on 500 response' do
-        # Per API docs: a 500 may indicate MODS generation failed while TEI/TFE
-        # were still stored. The service raises ServerError in either case —
-        # distinguishing partial vs full failure is a caller responsibility.
         stub_tapas_xq_store_failure(
           project_id: project.id,
           doc_id: core_file.id,


### PR DESCRIPTION
## Summary

- **D-01**: Rename `TapasXq::RetrievalService` → `TapasXq::Retrieval` and `TapasXq::StorageService` → `TapasXq::Storage`. Files, specs, and all callers updated. Git detects these as renames.
- **D-03**: Reorder `public`/`private` blocks in `Collection` — `to_solr` moved above `private`, removing the mid-class `public` re-declaration.

## Test plan
- [ ] 751 examples, 0 failures