### PR TITLE
Card 1.44 — notify project owners and reassign files on account deletion

### DIFF
--- a/app/mailers/account_deletion_mailer.rb
+++ b/app/mailers/account_deletion_mailer.rb
@@ -1,0 +1,8 @@
+class AccountDeletionMailer < ApplicationMailer
+  def contributor_files_notification(owner, core_files, deleted_user_display)
+    @owner = owner
+    @core_files = core_files
+    @deleted_user_display = deleted_user_display
+    mail(to: owner.email, subject: "TAPAS: files transferred to you after account deletion")
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -25,7 +25,6 @@ class Project < ApplicationRecord
 
   def project_group
     ProjectMember
-      .all
       .where(project_id: id)
       .group_by(&:role)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
   has_many :project_members, dependent: :destroy
   has_many :projects, through: :project_members
 
+  before_destroy :notify_and_reassign_contributed_files, prepend: true
+
   def role_in(project)
     project_members.find_by(project: project)&.role
   end
@@ -33,5 +35,25 @@ class User < ApplicationRecord
   # Check if user is an admin based on admin_at timestamp
   def admin?
     admin_at.present?
+  end
+
+  private
+
+  def notify_and_reassign_contributed_files
+    contributed_project_ids = project_members.where.not(role: "owner").pluck(:project_id)
+    return if contributed_project_ids.empty?
+
+    Project.where(id: contributed_project_ids).each do |project|
+      files = project.core_files.where(depositor_id: id)
+      next if files.empty?
+
+      project_owner = project.owner.first
+      next unless project_owner
+
+      AccountDeletionMailer
+        .contributor_files_notification(project_owner, files.to_a, name || email)
+        .deliver_later
+      files.update_all(depositor_id: project_owner.id)
+    end
   end
 end

--- a/app/views/account_deletion_mailer/contributor_files_notification.html.erb
+++ b/app/views/account_deletion_mailer/contributor_files_notification.html.erb
@@ -1,0 +1,15 @@
+<p>Hello <%= @owner.name || @owner.email %>,</p>
+
+<p>
+  The TAPAS account for <strong><%= @deleted_user_display %></strong> has been deleted.
+  The following files they deposited in your project have been transferred to you as the project owner.
+  The files themselves have not been changed.
+</p>
+
+<ul>
+  <% @core_files.each do |file| %>
+    <li><%= file.title %></li>
+  <% end %>
+</ul>
+
+<p>No action is required. Please contact TAPAS support if you have questions.</p>

--- a/app/views/account_deletion_mailer/contributor_files_notification.text.erb
+++ b/app/views/account_deletion_mailer/contributor_files_notification.text.erb
@@ -1,0 +1,11 @@
+Hello <%= @owner.name || @owner.email %>,
+
+The TAPAS account for <%= @deleted_user_display %> has been deleted.
+The following files they deposited in your project have been transferred to you as the project owner.
+The files themselves have not been changed.
+
+<% @core_files.each do |file| %>
+- <%= file.title %>
+<% end %>
+
+No action is required. Please contact TAPAS support if you have questions.

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -30,6 +30,6 @@
 
 <h3>Cancel my account</h3>
 
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Sorry to see you go. Please note that any files you've uploaded to projects will remain in those projects. Click 'Cancel' if you'd like to delete your files first.", turbo_confirm: "Sorry to see you go. Please note that any files you've uploaded to projects will remain in those projects. Click 'Cancel' if you'd like to delete your files first." }, method: :delete %></div>
 
 <%= link_to "Back", :back %>

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -110,7 +110,7 @@ RSpec.describe "Users", type: :request do
         let(:collection) { create(:collection, depositor: owner, project: project) }
         let!(:contributed_file) do
           project.project_members.create!(user: user, role: "contributor")
-          create(:core_file, depositor: user, collections: [collection])
+          create(:core_file, depositor: user, collections: [ collection ])
         end
 
         it "reassigns depositor_id on contributed files to the project owner" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -103,6 +103,35 @@ RSpec.describe "Users", type: :request do
           expect { delete user_registration_path, as: :json }.to change(User, :count).by(-1)
         end
       end
+
+      context "when the user has contributed files to a project they do not own" do
+        let(:owner) { create(:user) }
+        let(:project) { create(:project, depositor: owner) }
+        let(:collection) { create(:collection, depositor: owner, project: project) }
+        let!(:contributed_file) do
+          project.project_members.create!(user: user, role: "contributor")
+          create(:core_file, depositor: user, collections: [collection])
+        end
+
+        it "reassigns depositor_id on contributed files to the project owner" do
+          delete user_registration_path, as: :json
+          expect(contributed_file.reload.depositor_id).to eq(owner.id)
+        end
+
+        it "does not delete the contributed files" do
+          expect { delete user_registration_path, as: :json }.not_to change(CoreFile, :count)
+        end
+
+        it "emails the project owner with the list of transferred files" do
+          expect {
+            delete user_registration_path, as: :json
+          }.to have_enqueued_mail(AccountDeletionMailer, :contributor_files_notification)
+        end
+
+        it "still deletes the user account" do
+          expect { delete user_registration_path, as: :json }.to change(User, :count).by(-1)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## What this does

When a user deletes their account, the project owner is notified for any project where that user had uploaded files. The email lists the affected files, confirms they've been transferred, and lets the owner know no action is needed. The files themselves are unchanged.

Users are also shown a reminder before confirming deletion that any files they've uploaded to projects will remain in those projects.

## Changes

- `User` — `before_destroy` callback finds contributed files, emails each affected project owner, and reassigns depositor IDs
- `AccountDeletionMailer` — informational email to the receiving owner with HTML + text templates
- Account deletion confirm dialog — reminds users their uploaded files will stay in their projects
- Request specs cover owner notification and depositor reassignment; full suite green

## Known limitation

When a project has multiple owners, files are reassigned to whichever owner `project.owner.first` returns — the query is unordered, so the result is non-deterministic. This edge case is out of scope for this card but worth a follow-up.